### PR TITLE
Adding PlerkleSerialization trait to make Messenger trait more generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,6 +1834,7 @@ dependencies = [
 name = "messenger"
 version = "0.1.0"
 dependencies = [
+ "plerkle-serialization",
  "solana-geyser-plugin-interface",
 ]
 

--- a/messenger/Cargo.toml
+++ b/messenger/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/solana-geyser-plugin-interface"
 
 [dependencies]
 solana-geyser-plugin-interface  = { version = "=1.10.10" }
+plerkle-serialization={path= "../plerkle_serialization"}
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/messenger/src/lib.rs
+++ b/messenger/src/lib.rs
@@ -1,41 +1,14 @@
-use solana_geyser_plugin_interface::geyser_plugin_interface::{
-    ReplicaAccountInfo, ReplicaBlockInfo, ReplicaTransactionInfo, Result, SlotStatus,
+use {
+    plerkle_serialization::PlerkleSerialized,
+    solana_geyser_plugin_interface::geyser_plugin_interface::Result,
 };
 
-pub const ACCOUNT_STREAM: &'static str = "ACC";
-pub const SLOT_STREAM: &'static str = "SLT";
-pub const TRANSACTION_STREAM: &'static str = "TXN";
-pub const BLOCK_STREAM: &'static str = "BLK";
-pub const DATA_KEY: &'static str = "data";
-
-pub struct SerializedBlock<'a> {
-    bytes: &'a [u8],
-}
-
-impl<'a> SerializedBlock<'a> {
-    pub fn new(bytes: &'a [u8]) -> Self {
-        Self { bytes }
-    }
-
-    pub fn bytes(&self) -> &'a [u8] {
-        self.bytes
-    }
-}
+pub const DATA_KEY: &str = "data";
 
 pub trait Messenger {
     fn new() -> Result<Self>
     where
         Self: Sized;
 
-    // TODO: Make these also take types like SerializedAccount, etc.
-    // See SerializedBlock example.
-    fn send_account(&mut self, bytes: &[u8]) -> Result<()>;
-    fn send_slot_status(&mut self, bytes: &[u8]) -> Result<()>;
-    fn send_transaction(&mut self, bytes: &[u8]) -> Result<()>;
-    fn send_block(&mut self, bytes: SerializedBlock) -> Result<()>;
-
-    fn recv_account(&self) -> Result<()>;
-    fn recv_slot_status(&self) -> Result<()>;
-    fn recv_transaction(&self) -> Result<()>;
-    fn recv_block(&self) -> Result<()>;
+    fn send<'a, T: PlerkleSerialized<'a>>(&mut self, bytes: T) -> Result<()>;
 }

--- a/nft_api/src/ingest/main.rs
+++ b/nft_api/src/ingest/main.rs
@@ -3,10 +3,13 @@ use {
     flatbuffers::{ForwardsUOffset, Vector},
     gummyroll::state::change_log::ChangeLogEvent,
     lazy_static::lazy_static,
-    messenger::{ACCOUNT_STREAM, BLOCK_STREAM, DATA_KEY, SLOT_STREAM, TRANSACTION_STREAM},
+    messenger::DATA_KEY,
     nft_api_lib::events::handle_event,
-    plerkle_serialization::transaction_info_generated::transaction_info::{
-        self, root_as_transaction_info, TransactionInfo,
+    plerkle_serialization::{
+        transaction_info_generated::transaction_info::{
+            self, root_as_transaction_info, TransactionInfo,
+        },
+        ACCOUNT_STREAM, BLOCK_STREAM, SLOT_STREAM, TRANSACTION_STREAM,
     },
     redis::{
         streams::{StreamId, StreamKey, StreamReadOptions, StreamReadReply},

--- a/plerkle/src/geyser_plugin_nft.rs
+++ b/plerkle/src/geyser_plugin_nft.rs
@@ -176,7 +176,7 @@ impl<T: 'static + Messenger + Default + Send + Sync> GeyserPlugin for Plerkle<T>
                     Some(messenger) => {
                         let mut builder = FlatBufferBuilder::new();
                         let bytes = serialize_account(&mut builder, account, slot, is_startup);
-                        messenger.send_account(bytes)
+                        messenger.send(bytes)
                     }
                 }
             }
@@ -205,7 +205,7 @@ impl<T: 'static + Messenger + Default + Send + Sync> GeyserPlugin for Plerkle<T>
             Some(messenger) => {
                 let mut builder = FlatBufferBuilder::new();
                 let bytes = serialize_slot_status(&mut builder, slot, parent, status);
-                messenger.send_slot_status(bytes)
+                messenger.send(bytes)
             }
         }
     }
@@ -246,7 +246,7 @@ impl<T: 'static + Messenger + Default + Send + Sync> GeyserPlugin for Plerkle<T>
                     Some(messenger) => {
                         let mut builder = FlatBufferBuilder::new();
                         let bytes = serialize_transaction(&mut builder, transaction_info, slot);
-                        messenger.send_transaction(bytes)
+                        messenger.send(bytes)
                     }
                 }
             }
@@ -271,7 +271,7 @@ impl<T: 'static + Messenger + Default + Send + Sync> GeyserPlugin for Plerkle<T>
                     Some(messenger) => {
                         let mut builder = FlatBufferBuilder::new();
                         let bytes = serialize_block(&mut builder, block_info);
-                        messenger.send_block(bytes)
+                        messenger.send(bytes)
                     }
                 }
             }

--- a/plerkle_serialization/src/lib.rs
+++ b/plerkle_serialization/src/lib.rs
@@ -1,4 +1,9 @@
+pub mod account_info_generated;
+pub mod block_info_generated;
 pub mod slot_status_info_generated;
 pub mod transaction_info_generated;
-pub mod block_info_generated;
-pub mod account_info_generated;
+
+// Re-export plerkle_serialized at crate root level for
+// easier access.
+mod plerkle_serialized;
+pub use plerkle_serialized::*;

--- a/plerkle_serialization/src/plerkle_serialized.rs
+++ b/plerkle_serialization/src/plerkle_serialized.rs
@@ -1,0 +1,15 @@
+/// Some constnats that can be used as PlerkleSerialized key values.
+pub const ACCOUNT_STREAM: &str = "ACC";
+pub const SLOT_STREAM: &str = "SLT";
+pub const TRANSACTION_STREAM: &str = "TXN";
+pub const BLOCK_STREAM: &str = "BLK";
+
+/// This trait indicates data was serialized and supports the
+/// included methods to retrieve the serialized bytes and an
+/// arbitrary string storage key that can be used by other storage
+/// methods.
+pub trait PlerkleSerialized<'a> {
+    fn new(bytes: &'a [u8]) -> Self;
+    fn bytes(&self) -> &'a [u8];
+    fn key(&self) -> &'static str;
+}


### PR DESCRIPTION
## Summary
Beyond making Messenger more generic, the goal was to add some type safety.  Now `Messenger::send()` has to take a type that we expect to be the output of a specific serialization method, rather than a raw byte slice.

Also with this PR did some other minor cleanup of unused code.

After this PR I plan to re-add the `Messenger` receive method.  I have some ideas how to do that with ingest but they are not included yet with this current PR.

## Longer term ideas
A longer term, cleaner option might be to make the `PlerkleSerialization` trait include a `serialize()` method, and then `Messenger` could just take a type and call the type's `serialize()` method before sending it.  The current problem with this approach is that we don't just want to serialize a single type.  For example, the Geyser method called for account updates is:
```
    fn update_account(
        &mut self,
        account: ReplicaAccountInfoVersions,
        slot: u64,
        is_startup: bool,
    ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
```
But I don't want to necessarily serialize everything in `ReplicaAccountInfoVersions`, and I may want `slot` and `is_startup` as well.  So if I wanted to just implement a generic `serialize()` method on a type, I need to create a new type that takes the fields we want.  This is why I did not go further with this serialization trait for now.

## Testing
Continuous gummyroll test still passing.