### PR TITLE
Moving Redis code out of Ingest and into Redis Messenger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,6 +1896,7 @@ dependencies = [
 name = "messenger"
 version = "0.1.0"
 dependencies = [
+ "plerkle-serialization",
  "solana-geyser-plugin-interface",
 ]
 
@@ -2044,6 +2045,7 @@ dependencies = [
  "lazy_static",
  "messenger",
  "num-integer",
+ "plerkle",
  "plerkle-serialization",
  "redis",
  "regex",

--- a/messenger/Cargo.toml
+++ b/messenger/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/solana-geyser-plugin-interface"
 
 [dependencies]
 solana-geyser-plugin-interface  = { version = "=1.10.10" }
+plerkle-serialization={path= "../plerkle_serialization"}
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/messenger/src/lib.rs
+++ b/messenger/src/lib.rs
@@ -1,41 +1,18 @@
-use solana_geyser_plugin_interface::geyser_plugin_interface::{
-    ReplicaAccountInfo, ReplicaBlockInfo, ReplicaTransactionInfo, Result, SlotStatus,
-};
+use solana_geyser_plugin_interface::geyser_plugin_interface::Result;
 
-pub const ACCOUNT_STREAM: &'static str = "ACC";
-pub const SLOT_STREAM: &'static str = "SLT";
-pub const TRANSACTION_STREAM: &'static str = "TXN";
-pub const BLOCK_STREAM: &'static str = "BLK";
-pub const DATA_KEY: &'static str = "data";
-
-pub struct SerializedBlock<'a> {
-    bytes: &'a [u8],
-}
-
-impl<'a> SerializedBlock<'a> {
-    pub fn new(bytes: &'a [u8]) -> Self {
-        Self { bytes }
-    }
-
-    pub fn bytes(&self) -> &'a [u8] {
-        self.bytes
-    }
-}
+/// Some constants that can be used as stream key values.
+pub const ACCOUNT_STREAM: &str = "ACC";
+pub const SLOT_STREAM: &str = "SLT";
+pub const TRANSACTION_STREAM: &str = "TXN";
+pub const BLOCK_STREAM: &str = "BLK";
 
 pub trait Messenger {
     fn new() -> Result<Self>
     where
         Self: Sized;
 
-    // TODO: Make these also take types like SerializedAccount, etc.
-    // See SerializedBlock example.
-    fn send_account(&mut self, bytes: &[u8]) -> Result<()>;
-    fn send_slot_status(&mut self, bytes: &[u8]) -> Result<()>;
-    fn send_transaction(&mut self, bytes: &[u8]) -> Result<()>;
-    fn send_block(&mut self, bytes: SerializedBlock) -> Result<()>;
-
-    fn recv_account(&self) -> Result<()>;
-    fn recv_slot_status(&self) -> Result<()>;
-    fn recv_transaction(&self) -> Result<()>;
-    fn recv_block(&self) -> Result<()>;
+    fn add_stream(&mut self, stream_key: &'static str, _max_buffer_size: usize);
+    fn send(&mut self, stream_key: &'static str, bytes: &[u8]) -> Result<()>;
+    fn recv(&mut self) -> Result<()>;
+    fn get<'a>(&'a mut self, stream_key: &'static str) -> Result<Vec<(i64, &[u8])>>;
 }

--- a/nft_api/Cargo.toml
+++ b/nft_api/Cargo.toml
@@ -39,6 +39,7 @@ solana-sdk = { version = "=1.10.10" }
 lazy_static = "1.4.0"
 regex = "1.5.5"
 gummyroll-crud={path= "../programs/gummyroll_crud", features = ["no-entrypoint"]}
+plerkle={path= "../plerkle"}
 plerkle-serialization={path= "../plerkle_serialization"}
 
 [dependencies.num-integer]

--- a/plerkle/src/lib.rs
+++ b/plerkle/src/lib.rs
@@ -2,6 +2,6 @@ pub mod accounts_selector;
 mod error;
 pub mod geyser_plugin_nft;
 mod programs;
-mod redis_messenger;
-mod serializer;
+pub mod redis_messenger;
+pub mod serializer;
 pub mod transaction_selector;

--- a/plerkle/src/serializer.rs
+++ b/plerkle/src/serializer.rs
@@ -1,10 +1,7 @@
 use {
     flatbuffers::FlatBufferBuilder,
-    messenger::SerializedBlock,
     plerkle_serialization::{
-        account_info_generated::account_info::{
-            root_as_account_info, AccountInfo, AccountInfoArgs,
-        },
+        account_info_generated::account_info::{AccountInfo, AccountInfoArgs},
         block_info_generated,
         slot_status_info_generated::slot_status_info::{self, SlotStatusInfo, SlotStatusInfoArgs},
         transaction_info_generated::transaction_info::{
@@ -12,15 +9,9 @@ use {
         },
     },
     solana_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaAccountInfo, ReplicaBlockInfo, ReplicaTransactionInfo, Result, SlotStatus,
+        ReplicaAccountInfo, ReplicaBlockInfo, ReplicaTransactionInfo, SlotStatus,
     },
     solana_runtime::bank::RewardType,
-    solana_sdk::{instruction::CompiledInstruction, keccak, pubkey::Pubkey},
-    std::{
-        collections::HashMap,
-        fmt::{Debug, Formatter},
-        ops::Index,
-    },
 };
 
 pub fn serialize_account<'a>(
@@ -204,7 +195,7 @@ pub fn serialize_transaction<'a>(
 pub fn serialize_block<'a>(
     builder: &'a mut FlatBufferBuilder,
     block_info: &ReplicaBlockInfo,
-) -> SerializedBlock<'a> {
+) -> &'a [u8] {
     // Serialize blockash.
     let blockhash = Some(builder.create_string(&block_info.blockhash));
 
@@ -263,5 +254,5 @@ pub fn serialize_block<'a>(
 
     // Finalize buffer and return to caller.
     builder.finish(block_info, None);
-    SerializedBlock::new(builder.finished_data())
+    builder.finished_data()
 }


### PR DESCRIPTION
Also updating RedisMessenger to allow for stream `add` functionality.
Also some other minor cleanup.

## Testing
Looks to me like it performs the same as current main:
```
danenbm@danenbm-blade:~/Metaplex-Workspace/candyland$ yarn run ts-mocha -t 1000000 tests/continuous_gummyroll-test.ts
yarn run v1.22.18
$ /home/danenbm/Metaplex-Workspace/candyland/node_modules/.bin/ts-mocha -t 1000000 tests/continuous_gummyroll-test.ts
Using RPC: http://0.0.0.0:8899


  gummyroll-continuous
GRoLLMza82AiYN7W9S9KCCtCyyPRAQP2ifBy4v4D5RMD
TREE ID:  C5hcLDxr1oe9UZqhrrbqKyYmkRRjaKkWAhPL3nS8tzdB
Successfully completed:  25
Successfully completed:  50
    ✔ 1024 leaves replaced in batches of 25 (2762ms)


  1 passing (9s)

Done in 14.37s.
```