### PR TITLE
Enable user-specified Redis stream lengths

### DIFF
--- a/messenger/src/lib.rs
+++ b/messenger/src/lib.rs
@@ -11,7 +11,8 @@ pub trait Messenger {
     where
         Self: Sized;
 
-    fn add_stream(&mut self, stream_key: &'static str, _max_buffer_size: usize);
+    fn add_stream(&mut self, stream_key: &'static str);
+    fn set_buffer_size(&mut self, stream_key: &'static str, max_buffer_size: usize);
     fn send(&mut self, stream_key: &'static str, bytes: &[u8]) -> Result<()>;
     fn recv(&mut self) -> Result<()>;
     fn get<'a>(&'a mut self, stream_key: &'static str) -> Result<Vec<(i64, &[u8])>>;

--- a/nft_api/src/ingest/main.rs
+++ b/nft_api/src/ingest/main.rs
@@ -293,10 +293,10 @@ pub async fn batch_init_service(
 async fn main() {
     // Setup Redis Messenger.
     let mut messenger = RedisMessenger::new().unwrap();
-    messenger.add_stream(ACCOUNT_STREAM, 0);
-    messenger.add_stream(SLOT_STREAM, 0);
-    messenger.add_stream(TRANSACTION_STREAM, 0);
-    messenger.add_stream(BLOCK_STREAM, 0);
+    messenger.add_stream(ACCOUNT_STREAM);
+    messenger.add_stream(SLOT_STREAM);
+    messenger.add_stream(TRANSACTION_STREAM);
+    messenger.add_stream(BLOCK_STREAM);
 
     // Setup Postgres.
     let pool = PgPoolOptions::new()

--- a/plerkle/src/geyser_plugin_nft.rs
+++ b/plerkle/src/geyser_plugin_nft.rs
@@ -140,11 +140,14 @@ impl<T: 'static + Messenger + Default + Send + Sync> GeyserPlugin for Plerkle<T>
 
         // Setup messenger.
         let mut messenger = T::new()?;
-        messenger.add_stream(ACCOUNT_STREAM, 0);
-        messenger.add_stream(SLOT_STREAM, 0);
-        messenger.add_stream(TRANSACTION_STREAM, 0);
-        messenger.add_stream(BLOCK_STREAM, 0);
-
+        messenger.add_stream(ACCOUNT_STREAM);
+        messenger.add_stream(SLOT_STREAM);
+        messenger.add_stream(TRANSACTION_STREAM);
+        messenger.add_stream(BLOCK_STREAM);
+        messenger.set_buffer_size(ACCOUNT_STREAM, 5000);
+        messenger.set_buffer_size(SLOT_STREAM, 5000);
+        messenger.set_buffer_size(TRANSACTION_STREAM, 5000);
+        messenger.set_buffer_size(BLOCK_STREAM, 5000);
         self.messenger = Some(messenger);
 
         Ok(())


### PR DESCRIPTION
### Notes
- Before these were in the Redis Messenger struct but not used.  This PR enables using them.
- Also makes Redis read failures non-panic failures (only log).
- Also some other misc. minor cleanup.

### Testing
Continuous gummyroll test still passing.