### PR TITLE
Gumball Machine Dispense Payments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,6 +1384,7 @@ dependencies = [
  "bytemuck",
  "gummyroll",
  "mpl-token-metadata",
+ "spl-token 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/programs/gumball-machine/Cargo.toml
+++ b/programs/gumball-machine/Cargo.toml
@@ -18,6 +18,7 @@ default = []
 [dependencies]
 anchor-lang = { path="../../deps/anchor/lang" }
 anchor-spl = { path="../../deps/anchor/spl" }
+spl-token = "3.3.0"
 mpl-token-metadata = { git = "https://github.com/jarry-xiao/metaplex-program-library", rev="7e2810a", features = [ "no-entrypoint" ] }
 bubblegum = { path = "../bubblegum", features = ["cpi"] }
 gummyroll = { path = "../gummyroll", features = ["cpi"] }

--- a/programs/gumball-machine/src/lib.rs
+++ b/programs/gumball-machine/src/lib.rs
@@ -1,8 +1,16 @@
 use anchor_lang::{
     prelude::*,
-    solana_program::{keccak::hashv, sysvar, sysvar::SysvarId},
+    solana_program::{
+        keccak::hashv, 
+        sysvar, 
+        sysvar::SysvarId, 
+        pubkey::Pubkey, 
+        program::{invoke, invoke_signed},
+        system_instruction,
+    },
 };
-use anchor_spl::token::Mint;
+use anchor_spl::token::{Mint, TokenAccount, Token, Transfer, transfer};
+use spl_token::native_mint;
 use bubblegum::program::Bubblegum;
 use bubblegum::state::metaplex_adapter::UseMethod;
 use bubblegum::state::metaplex_adapter::Uses;
@@ -55,13 +63,59 @@ pub struct UpdateHeaderMetadata<'info> {
 }
 
 #[derive(Accounts)]
-pub struct Dispense<'info> {
+pub struct DispenseSol<'info> {
     /// CHECK: Validation occurs in instruction
     #[account(mut)]
     gumball_machine: AccountInfo<'info>,
 
     #[account(mut)]
     payer: Signer<'info>,
+
+    /// CHECK: Validation occurs in instruction
+    #[account(mut)]
+    receiver: AccountInfo<'info>,
+    system_program: Program<'info, System>,
+
+    #[account(
+        seeds = [gumball_machine.key().as_ref()],
+        bump,
+    )]
+    /// CHECK: PDA is checked on CPI for mint
+    willy_wonka: AccountInfo<'info>,
+    /// CHECK: Address is verified
+    #[account(address = SlotHashes::id())]
+    recent_blockhashes: UncheckedAccount<'info>,
+    /// CHECK: Address is verified
+    #[account(address = sysvar::instructions::id())]
+    instruction_sysvar_account: UncheckedAccount<'info>,
+    /// CHECK: PDA is checked in CPI from Bubblegum to Gummyroll
+    /// This key must sign for all write operations to the NFT Metadata stored in the Merkle slab
+    bubblegum_authority: AccountInfo<'info>,
+    /// CHECK: PDA is checked in Bubblegum
+    #[account(mut)]
+    nonce: AccountInfo<'info>,
+    gummyroll: Program<'info, Gummyroll>,
+    /// CHECK: Validation occurs in Gummyroll
+    #[account(mut)]
+    merkle_slab: AccountInfo<'info>,
+    bubblegum: Program<'info, Bubblegum>,
+}
+
+#[derive(Accounts)]
+pub struct DispenseToken<'info> {
+    /// CHECK: Validation occurs in instruction
+    #[account(mut)]
+    gumball_machine: AccountInfo<'info>,
+
+    payer: Signer<'info>,
+    
+    #[account(mut)]
+    payer_tokens: Account<'info, TokenAccount>,
+
+    #[account(mut)]
+    receiver: Account<'info, TokenAccount>,
+    token_program: Program<'info, Token>,
+
     #[account(
         seeds = [gumball_machine.key().as_ref()],
         bump,
@@ -96,10 +150,103 @@ pub struct Destroy<'info> {
     authority: Signer<'info>,
 }
 
+#[inline(always)]
+// For efficiency, this returns the GumballMachineHeader because it's required to validate
+// payment parameters. But the main purpose of this function is to determine which config
+// line to mint to the user, and CPI to bubblegum to actually execute the mint
+fn find_and_mint_compressed_nft<'info>(
+    gumball_machine: &AccountInfo<'info>,
+    payer: &Signer<'info>,
+    willy_wonka: &AccountInfo<'info>,
+    willy_wonka_bump: &u8,
+    recent_blockhashes: &UncheckedAccount<'info>,
+    instruction_sysvar_account: &UncheckedAccount<'info>,
+    bubblegum_authority: &AccountInfo<'info>,
+    nonce: &AccountInfo<'info>,
+    gummyroll: &Program<'info, Gummyroll>,
+    merkle_slab: &AccountInfo<'info>,
+    bubblegum: &Program<'info, Bubblegum>,
+    num_items: u64
+) -> Result<GumballMachineHeader> {
+    // Load all data
+    let mut gumball_machine_data = gumball_machine.try_borrow_mut_data()?;
+    let (mut header_bytes, config_data) =
+        gumball_machine_data.split_at_mut(std::mem::size_of::<GumballMachineHeader>());
+    let gumball_header = GumballMachineHeader::load_mut_bytes(&mut header_bytes)?;
+    let clock = Clock::get()?;
+    assert!(clock.unix_timestamp > gumball_header.go_live_date);
+    let size = gumball_header.max_items as usize;
+    let index_array_size = std::mem::size_of::<u32>() * size;
+    let config_size = gumball_header.extension_len * size;
+    let line_size = gumball_header.extension_len;
+
+    assert!(config_data.len() == index_array_size + config_size);
+    let (indices_data, config_lines_data) = config_data.split_at_mut(index_array_size);
+
+    // TODO: Validate data
+
+    let mut indices = cast_slice_mut::<u8, u32>(indices_data);
+    for _ in 0..(num_items as usize).max(1).min(gumball_header.remaining) {
+        // Get 8 bytes of entropy from the SlotHashes sysvar
+        let mut buf: [u8; 8] = [0; 8];
+        buf.copy_from_slice(
+            &hashv(&[
+                &recent_blockhashes.data.borrow(),
+                &gumball_header.remaining.to_le_bytes(),
+            ])
+            .as_ref()[..8],
+        );
+        let entropy = u64::from_le_bytes(buf);
+        // Shuffle the list of indices using Fisher-Yates
+        let selected = entropy % gumball_header.remaining as u64;
+        gumball_header.remaining -= 1;
+        (&mut indices).swap(selected as usize, gumball_header.remaining);
+        // Pull out config line from the data
+        let random_config_index = indices[gumball_header.remaining] as usize * line_size;
+        let config_line =
+            config_lines_data[random_config_index..random_config_index + line_size].to_vec();
+
+        let message = get_metadata_args(
+            gumball_header.url_base,
+            gumball_header.name_base,
+            gumball_header.symbol,
+            gumball_header.seller_fee_basis_points,
+            gumball_header.is_mutable != 0,
+            gumball_header.collection_key,
+            None,
+            gumball_header.creator_address,
+            random_config_index,
+            config_line,
+        );
+
+        let seed = gumball_machine.key();
+        let seeds = &[seed.as_ref(), &[*willy_wonka_bump]];
+        let authority_pda_signer = &[&seeds[..]];
+        let cpi_ctx = CpiContext::new_with_signer(
+            bubblegum.to_account_info(),
+            bubblegum::cpi::accounts::Mint {
+                mint_authority: willy_wonka.to_account_info(),
+                authority: bubblegum_authority.to_account_info(),
+                nonce: nonce.to_account_info(),
+                gummyroll_program: gummyroll.to_account_info(),
+                owner: payer.to_account_info(),
+                delegate: payer.to_account_info(),
+                merkle_slab: merkle_slab.to_account_info(),
+            },
+            authority_pda_signer,
+        );
+        bubblegum::cpi::mint(cpi_ctx, message)?;
+    }
+    Ok(*gumball_header)
+}
+
 #[program]
 pub mod gumball_machine {
     use super::*;
 
+    // TODO(sorend): consider validating receiver in here. I.e. forcing the receiver to be the
+    // associated token account of creator_address and mint. This restricts payment reciept options,
+    // but it allows validation that all initialized gumball machines can receive payment
     pub fn initialize_gumball_machine(
         ctx: Context<InitGumballMachine>,
         max_depth: u32,
@@ -113,6 +260,7 @@ pub mod gumball_machine {
         price: u64,
         go_live_date: i64,
         bot_wallet: Pubkey,
+        receiver: Pubkey,
         authority: Pubkey,
         collection_key: Pubkey,
         extension_len: u64,
@@ -135,6 +283,7 @@ pub mod gumball_machine {
             price,
             go_live_date,
             bot_wallet,
+            receiver,
             authority,
             mint: ctx.accounts.mint.key(),
             collection_key,
@@ -284,9 +433,12 @@ pub mod gumball_machine {
             None => {}
         }
         match bot_wallet {
+            // TODO(sorend): do we want to apply some validation here?
+            // If this will only collect SOL then this is fine, if not then need to validate that it's a TokenAccount with a mint corresponding to project mint
             Some(bw) => gumball_machine.bot_wallet = bw,
             None => {}
         }
+        // TODO(sorend): consider allowing changes to receiver, requires validation of receiver
         match max_mint_size {
             Some(mms) => gumball_machine.max_mint_size = mms.max(1).min(gumball_machine.max_items),
             None => {}
@@ -294,77 +446,77 @@ pub mod gumball_machine {
         Ok(())
     }
 
-    // TODO(sorend): implement payments (standard token transfer if anything but native sol, if native sol then system_instruction)
-    pub fn dispense(ctx: Context<Dispense>, num_items: u64) -> Result<()> {
-        // Load all data
-        let mut gumball_machine_data = ctx.accounts.gumball_machine.try_borrow_mut_data()?;
-        let (mut header_bytes, config_data) =
-            gumball_machine_data.split_at_mut(std::mem::size_of::<GumballMachineHeader>());
-        let gumball_header = GumballMachineHeader::load_mut_bytes(&mut header_bytes)?;
-        let clock = Clock::get()?;
-        assert!(clock.unix_timestamp > gumball_header.go_live_date);
-        let size = gumball_header.max_items as usize;
-        let index_array_size = std::mem::size_of::<u32>() * size;
-        let config_size = gumball_header.extension_len * size;
-        let line_size = gumball_header.extension_len;
+    // @notice: payments cannot be carried out in wrapped sol. If the wrapped SOL mint key is given, then we execute a native SOL transfer
+    pub fn dispense_nft_sol(ctx: Context<DispenseSol>, num_items: u64) -> Result<()> {
+        let gumball_header = find_and_mint_compressed_nft(
+            &ctx.accounts.gumball_machine,
+            &ctx.accounts.payer,
+            &ctx.accounts.willy_wonka,
+            ctx.bumps.get("willy_wonka").unwrap(),
+            &ctx.accounts.recent_blockhashes,
+            &ctx.accounts.instruction_sysvar_account,
+            &ctx.accounts.bubblegum_authority,
+            &ctx.accounts.nonce,
+            &ctx.accounts.gummyroll,
+            &ctx.accounts.merkle_slab,
+            &ctx.accounts.bubblegum,
+            num_items
+        )?;
 
-        assert!(config_data.len() == index_array_size + config_size);
-        let (indices_data, config_lines_data) = config_data.split_at_mut(index_array_size);
+        // Process payment for NFT
+        assert_eq!(&gumball_header.receiver.key(), &ctx.accounts.receiver.key());
 
-        // TODO: Validate data
+        // Can only use this instruction for projects seeking SOL
+        let wrapped_sol_pubkey: Pubkey = native_mint::ID;
+        assert_eq!(gumball_header.mint, wrapped_sol_pubkey);
 
-        let mut indices = cast_slice_mut::<u8, u32>(indices_data);
-        for _ in 0..(num_items as usize).max(1).min(gumball_header.remaining) {
-            // Get 8 bytes of entropy from the SlotHashes sysvar
-            let mut buf: [u8; 8] = [0; 8];
-            buf.copy_from_slice(
-                &hashv(&[
-                    &ctx.accounts.recent_blockhashes.data.borrow(),
-                    &gumball_header.remaining.to_le_bytes(),
-                ])
-                .as_ref()[..8],
-            );
-            let entropy = u64::from_le_bytes(buf);
-            // Shuffle the list of indices using Fisher-Yates
-            let selected = entropy % gumball_header.remaining as u64;
-            gumball_header.remaining -= 1;
-            (&mut indices).swap(selected as usize, gumball_header.remaining);
-            // Pull out config line from the data
-            let random_config_index = indices[gumball_header.remaining] as usize * line_size;
-            let config_line =
-                config_lines_data[random_config_index..random_config_index + line_size].to_vec();
+        invoke(
+            &system_instruction::transfer(
+                &ctx.accounts.payer.key(),
+                &ctx.accounts.receiver.key(),
+                gumball_header.price
+            ),
+            &[
+                ctx.accounts.payer.to_account_info(),
+                ctx.accounts.receiver.to_account_info(),
+                ctx.accounts.system_program.to_account_info()
+            ]
+        )?;
 
-            let message = get_metadata_args(
-                gumball_header.url_base,
-                gumball_header.name_base,
-                gumball_header.symbol,
-                gumball_header.seller_fee_basis_points,
-                gumball_header.is_mutable != 0,
-                gumball_header.collection_key,
-                None,
-                gumball_header.creator_address,
-                random_config_index,
-                config_line,
-            );
+        Ok(())
+    }
 
-            let seed = ctx.accounts.gumball_machine.key();
-            let seeds = &[seed.as_ref(), &[*ctx.bumps.get("willy_wonka").unwrap()]];
-            let authority_pda_signer = &[&seeds[..]];
-            let cpi_ctx = CpiContext::new_with_signer(
-                ctx.accounts.bubblegum.to_account_info(),
-                bubblegum::cpi::accounts::Mint {
-                    mint_authority: ctx.accounts.willy_wonka.to_account_info(),
-                    authority: ctx.accounts.bubblegum_authority.to_account_info(),
-                    nonce: ctx.accounts.nonce.to_account_info(),
-                    gummyroll_program: ctx.accounts.gummyroll.to_account_info(),
-                    owner: ctx.accounts.payer.to_account_info(),
-                    delegate: ctx.accounts.payer.to_account_info(),
-                    merkle_slab: ctx.accounts.merkle_slab.to_account_info(),
-                },
-                authority_pda_signer,
-            );
-            bubblegum::cpi::mint(cpi_ctx, message)?;
-        }
+    pub fn dispense_nft_token(ctx: Context<DispenseToken>, num_items: u64) -> Result<()> {
+        let gumball_header = find_and_mint_compressed_nft(
+            &ctx.accounts.gumball_machine,
+            &ctx.accounts.payer,
+            &ctx.accounts.willy_wonka,
+            ctx.bumps.get("willy_wonka").unwrap(),
+            &ctx.accounts.recent_blockhashes,
+            &ctx.accounts.instruction_sysvar_account,
+            &ctx.accounts.bubblegum_authority,
+            &ctx.accounts.nonce,
+            &ctx.accounts.gummyroll,
+            &ctx.accounts.merkle_slab,
+            &ctx.accounts.bubblegum,
+            num_items
+        )?;
+
+        // Process payment for NFT
+        assert_eq!(&gumball_header.receiver.key(), &ctx.accounts.receiver.key());
+        assert_eq!(ctx.accounts.payer_tokens.mint, gumball_header.mint);
+        transfer(
+            CpiContext::new(
+                ctx.accounts.token_program.to_account_info(),
+                Transfer {
+                    from: ctx.accounts.payer_tokens.to_account_info(),
+                    to: ctx.accounts.receiver.to_account_info(),
+                    authority: ctx.accounts.payer.to_account_info(),
+                }
+            ),
+            gumball_header.price
+        )?;
+
         Ok(())
     }
 

--- a/programs/gumball-machine/src/state/mod.rs
+++ b/programs/gumball-machine/src/state/mod.rs
@@ -5,7 +5,7 @@ use std::mem::size_of;
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod)]
 #[repr(C)]
-// Current Size: 352 bytes
+// Current Size: 384 bytes
 pub struct GumballMachineHeader {
     // TODO: Add more fields
     // Used to programmatically create the url and name for each field.
@@ -27,7 +27,9 @@ pub struct GumballMachineHeader {
     pub mint: Pubkey,
     // Used to collect bot fees
     pub bot_wallet: Pubkey,
+    pub receiver: Pubkey,
     pub authority: Pubkey,
+    // TokenMetadata collection pointer
     pub collection_key: Pubkey,
     // Force a single creator (use Hydra)
     pub creator_address: Pubkey,

--- a/tests/gumball-machine-serde.ts
+++ b/tests/gumball-machine-serde.ts
@@ -24,6 +24,7 @@ type GumballMachineHeader = {
   goLiveDate: BN,               // i64
   mint: PublicKey,              
   botWallet: PublicKey,
+  receiver: PublicKey,
   authority: PublicKey,
   collectionKey: PublicKey,
   creatorAddress: PublicKey,
@@ -60,6 +61,7 @@ export function decodeGumballMachine(buffer: Buffer, accountSize: number): OnCha
       goLiveDate: new BN(reader.readFixedArray(8), null, 'le'),
       mint: readPublicKey(reader),
       botWallet: readPublicKey(reader),
+      receiver: readPublicKey(reader),
       authority: readPublicKey(reader),
       collectionKey: readPublicKey(reader),
       creatorAddress: readPublicKey(reader),


### PR DESCRIPTION
Changes:
- Add payments for dispensing NFTs (separate instruction for SOL and SPL tokens, reason explained below)
- Add tests for payments, including test that mints multiple NFTs
- Small refactor of utility test methods

**Important Design Decision -- Multiple Dispense Instructions for Native SOL vs SPL Token**

Originally, there was a single dispense function that was to handle projects that wanted to be paid out in SPL Tokens or in native SOL. The issue with this approach, is that it required the client to pass dummy arguments to the instruction, to satisfy the requirements of the accounts context. I.e. there would need to be two TokenAccounts in the instruction context, if the user was making a purchase in native sol, they would need to supply two junk TokenAccounts for the instruction to go through. This seemed confusing, and not ideal. Instead, we've implemented two instructions, one for purchases in native sol and another for purchases in SPL token. The downside here is that the client needs to know which instruction to use, depending on the project's `GumballMachineHeader`. However, they effectively already had to know this in order to pull the correct payment accounts, anyways. And with this approach we do not need any wasted accounts in the instruction context.