### PR TITLE
Transaction Atomicity Attack Prevention

### DIFF
--- a/programs/gumball-machine/src/lib.rs
+++ b/programs/gumball-machine/src/lib.rs
@@ -190,7 +190,7 @@ fn find_and_mint_compressed_nft<'info>(
     num_items: u64
 ) -> Result<GumballMachineHeader> {
     
-    // Prevent bot attacks
+    // Prevent atomic transaction exploit attacks
     // TODO: potentially record information about botting now as pretains to payments to bot_wallet
     assert_valid_single_instruction_transaction(instruction_sysvar_account)?;
 

--- a/tests/gumball-machine-test.ts
+++ b/tests/gumball-machine-test.ts
@@ -17,7 +17,7 @@ import {
   LAMPORTS_PER_SOL,
   TransactionInstruction,
 } from "@solana/web3.js";
-import { assert, expect } from "chai";
+import { assert } from "chai";
 
 import { buildTree, Tree } from "./merkle-tree";
 import {


### PR DESCRIPTION
Summary of Changes:

- onchain atomicity preventative assertions
- tests for transactions with multiple instructions, and with a single instruction
- ~~tests for transactions calling dispense through CPI with only one instruction~~ omitted for now due to complexity of test, and low priority attack vector which should be trivially caught.

This PR adds two checks to `dispense_nft_sol` and `dispense_token_sol`. These checks ensure that the transaction containing either `dispense_nft_sol` or  i`dispense_token_sol` has only one instruction, and that the instruction is NOT to another instruction which CPI's to `GumballMachine`. This prevents a malicious user from taking advantage of the atomicity of transactions by trivially executing a failing transaction if they did not mint an NFT with the properties that they desired. More details are annotated in the contract.