### PR TITLE
[CMT] Reenable fast forward proof leaf

### DIFF
--- a/lib/concurrent-merkle-tree/src/error.rs
+++ b/lib/concurrent-merkle-tree/src/error.rs
@@ -12,14 +12,12 @@ pub enum CMTError {
     TreeFull,
     #[error("Tree already initialized")]
     TreeAlreadyInitialized,
-    #[error("Leaf was updated since proof was issued")]
-    LeafAlreadyUpdated,
     #[error("Invalid number of bytes passed for node (expected 32 bytes)")]
     InvalidNodeByteLength,
     #[error("Root not found in changelog buffer")]
     RootNotFound,
     #[error(
-        "Valid proof was passed to an empty leaf, but it was filled since the proof was issued"
+        "Valid proof was passed to a leaf, but it's value has changed since the proof was issued"
     )]
-    EmptyLeafSpotTaken,
+    LeafContentsModified,
 }

--- a/lib/concurrent-merkle-tree/src/log.rs
+++ b/lib/concurrent-merkle-tree/src/log.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "sol-log")]
-use solana_program::{log::sol_log_compute_units, msg};
-
 macro_rules! solana_logging {
     ($message:literal, $($arg:tt)*) => {
         #[cfg(feature = "log")]

--- a/lib/concurrent-merkle-tree/tests/tests.rs
+++ b/lib/concurrent-merkle-tree/tests/tests.rs
@@ -107,7 +107,7 @@ async fn test_prove_leaf() {
                     off_chain_tree.get_root(),
                     off_chain_tree.get_leaf(random_leaf_idx),
                     new_leaf,
-                    off_chain_tree.get_proof_of_leaf(random_leaf_idx),
+                    &off_chain_tree.get_proof_of_leaf(random_leaf_idx),
                     random_leaf_idx as u32,
                 )
                 .unwrap();
@@ -135,7 +135,7 @@ async fn test_initialize_with_root() {
         .initialize_with_root(
             tree.get_root(),
             tree.get_leaf(last_leaf_idx),
-            tree.get_proof_of_leaf(last_leaf_idx),
+            &tree.get_proof_of_leaf(last_leaf_idx),
             last_leaf_idx as u32,
         )
         .unwrap();
@@ -169,7 +169,7 @@ async fn test_replaces() {
                 tree.get_root(),
                 tree.get_leaf(i),
                 leaf,
-                tree.get_proof_of_leaf(i),
+                &tree.get_proof_of_leaf(i),
                 i as u32,
             )
             .unwrap();
@@ -187,7 +187,7 @@ async fn test_replaces() {
                 tree.get_root(),
                 tree.get_leaf(index),
                 leaf,
-                tree.get_proof_of_leaf(index),
+                &tree.get_proof_of_leaf(index),
                 index as u32,
             )
             .unwrap();


### PR DESCRIPTION
- Re-enable for logical consistency
- Fix bug in replace that failed to check if leaf was changed
- Add test checking to see if leaf has changed