### PR TITLE
External Configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,6 +620,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "candy-wrapper"
+version = "0.1.0"
+dependencies = [
+ "solana-program",
+]
+
+[[package]]
 name = "caps"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,6 +1545,7 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "bytemuck",
+ "candy-wrapper",
  "concurrent-merkle-tree",
 ]
 
@@ -2167,9 +2175,11 @@ name = "messenger"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "figment",
  "log",
  "plerkle-serialization",
  "redis",
+ "serde",
  "solana-geyser-plugin-interface",
  "thiserror",
 ]
@@ -2345,6 +2355,7 @@ dependencies = [
  "chrono",
  "csv",
  "digital_asset_types",
+ "figment",
  "flatbuffers",
  "futures-util",
  "gummyroll",
@@ -2762,6 +2773,7 @@ dependencies = [
  "base64 0.13.0",
  "bs58 0.4.0",
  "bytemuck",
+ "figment",
  "flatbuffers",
  "hex",
  "lazy_static",

--- a/contracts/Anchor.toml
+++ b/contracts/Anchor.toml
@@ -1,6 +1,5 @@
 [programs.localnet]
 gummyroll = "GRoLLMza82AiYN7W9S9KCCtCyyPRAQP2ifBy4v4D5RMD"
-gummyroll_crud = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 bubblegum = "BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY"
 gumball_machine = "GBALLoMcmimUutWvtNdFFGH5oguS7ghUUV6toQPppuTW"
 sugar_shack = "9T5Xv2cJRydUBqvdK7rLGuNGqhkA8sU8Yq1rGN7hExNK"

--- a/contracts/programs/bubblegum/src/lib.rs
+++ b/contracts/programs/bubblegum/src/lib.rs
@@ -69,14 +69,12 @@ pub struct CreateTree<'info> {
 
 #[derive(Accounts)]
 pub struct MintV1<'info> {
-    /// CHECK: This account is neither written to nor read from.
     pub mint_authority: Signer<'info>,
     #[account(
+    mut,
     seeds = [merkle_slab.key().as_ref()],
     bump,
     )]
-    /// CHECK: This account is neither written to nor read from.
-    #[account(mut)]
     pub authority: Account<'info, Nonce>,
     pub candy_wrapper: Program<'info, CandyWrapper>,
     pub gummyroll_program: Program<'info, Gummyroll>,
@@ -95,7 +93,6 @@ pub struct Burn<'info> {
     seeds = [merkle_slab.key().as_ref()],
     bump,
     )]
-    /// CHECK: This account is neither written to nor read from.
     pub authority: Account<'info, Nonce>,
     pub candy_wrapper: Program<'info, CandyWrapper>,
     pub gummyroll_program: Program<'info, Gummyroll>,
@@ -103,8 +100,8 @@ pub struct Burn<'info> {
     pub owner: UncheckedAccount<'info>,
     /// CHECK: This account is chekced in the instruction
     pub delegate: UncheckedAccount<'info>,
+
     #[account(mut)]
-    /// CHECK: unsafe
     pub merkle_slab: UncheckedAccount<'info>,
 }
 

--- a/contracts/programs/bubblegum/src/lib.rs
+++ b/contracts/programs/bubblegum/src/lib.rs
@@ -102,6 +102,7 @@ pub struct Burn<'info> {
     pub delegate: UncheckedAccount<'info>,
 
     #[account(mut)]
+    /// CHECK: This account is chekced in the instruction
     pub merkle_slab: UncheckedAccount<'info>,
 }
 

--- a/contracts/tests/bubblegum-test-rpc.ts
+++ b/contracts/tests/bubblegum-test-rpc.ts
@@ -42,6 +42,7 @@ import {TokenProgramVersion, Version} from "../sdk/bubblegum/src/generated";
 import {sleep} from "@metaplex-foundation/amman/dist/utils";
 import {verbose} from "sqlite3";
 import {bs58} from "@project-serum/anchor/dist/cjs/utils/bytes";
+import {CANDY_WRAPPER_PROGRAM_ID} from "../sdk/utils";
 
 // @ts-ignore
 let Bubblegum;
@@ -157,6 +158,7 @@ describe("bubblegum", () => {
     const initGummyrollIx = createCreateTreeInstruction(
       {
         treeCreator: payer.publicKey,
+        candyWrapper: CANDY_WRAPPER_PROGRAM_ID,
         payer: payer.publicKey,
         authority: authority,
         gummyrollProgram: GummyrollProgramId,
@@ -221,6 +223,7 @@ describe("bubblegum", () => {
           {
             mintAuthority: payer.publicKey,
             authority: treeAuthority,
+            candyWrapper: CANDY_WRAPPER_PROGRAM_ID,
             gummyrollProgram: GummyrollProgramId,
             owner: payer.publicKey,
             delegate: payer.publicKey,
@@ -258,6 +261,7 @@ describe("bubblegum", () => {
           let transferIx = createTransferInstruction(
             {
               authority: treeAuthority,
+              candyWrapper: CANDY_WRAPPER_PROGRAM_ID,
               owner: payer.publicKey,
               delegate: payer.publicKey,
               newOwner: destination.publicKey,
@@ -284,6 +288,7 @@ describe("bubblegum", () => {
           let delegateIx = await createDelegateInstruction(
             {
               authority: treeAuthority,
+              candyWrapper: CANDY_WRAPPER_PROGRAM_ID,
               owner: destination.publicKey,
               previousDelegate: destination.publicKey,
               newDelegate: delegateKey.publicKey,
@@ -308,6 +313,7 @@ describe("bubblegum", () => {
           let delTransferIx = createTransferInstruction(
             {
               authority: treeAuthority,
+              candyWrapper: CANDY_WRAPPER_PROGRAM_ID,
               owner: destination.publicKey,
               delegate: delegateKey.publicKey,
               newOwner: payer.publicKey,
@@ -332,7 +338,6 @@ describe("bubblegum", () => {
               commitment: "confirmed",
             }
           );
-
         }
 
         let [voucher] = await PublicKey.findProgramAddress(
@@ -350,6 +355,7 @@ describe("bubblegum", () => {
             let redeemIx = createRedeemInstruction(
               {
                 authority: treeAuthority,
+                candyWrapper: CANDY_WRAPPER_PROGRAM_ID,
                 owner: payer.publicKey,
                 delegate: payer.publicKey,
                 gummyrollProgram: GummyrollProgramId,
@@ -391,6 +397,7 @@ describe("bubblegum", () => {
             const cancelRedeemIx = createCancelRedeemInstruction(
               {
                 authority: treeAuthority,
+                candyWrapper: CANDY_WRAPPER_PROGRAM_ID,
                 owner: payer.publicKey,
                 gummyrollProgram: GummyrollProgramId,
                 merkleSlab: merkleRollKeypair.publicKey,
@@ -417,6 +424,7 @@ describe("bubblegum", () => {
               {
                 authority: treeAuthority,
                 owner: payer.publicKey,
+                candyWrapper: CANDY_WRAPPER_PROGRAM_ID,
                 delegate: payer.publicKey,
                 gummyrollProgram: GummyrollProgramId,
                 merkleSlab: merkleRollKeypair.publicKey,
@@ -439,8 +447,6 @@ describe("bubblegum", () => {
               }
             );
           }
-
-
 
           console.log("Decompressing - ", asset.toBase58())
 

--- a/contracts/tests/bubblegum-test.ts
+++ b/contracts/tests/bubblegum-test.ts
@@ -348,13 +348,8 @@ describe("bubblegum", () => {
         Bubblegum.programId
       );
 
-      let [tokenMint] = await PublicKey.findProgramAddress(
-        [asset.toBuffer(), TOKEN_PROGRAM_ID.toBuffer()],
-        Bubblegum.programId
-      ); //TODO -> change this for v1 id must be the mint
-
       let [mintAuthority] = await PublicKey.findProgramAddress(
-        [tokenMint.toBuffer()],
+        [asset.toBuffer()],
         Bubblegum.programId
       );
 
@@ -392,13 +387,13 @@ describe("bubblegum", () => {
           tokenAccount: await Token.getAssociatedTokenAddress(
             ASSOCIATED_TOKEN_PROGRAM_ID,
             TOKEN_PROGRAM_ID,
-            tokenMint,
+            asset,
             payer.publicKey
           ),
-          mint: tokenMint,
+          mint: asset,
           mintAuthority: mintAuthority,
-          metadata: await getMetadata(tokenMint),
-          masterEdition: await getMasterEdition(tokenMint),
+          metadata: await getMetadata(asset),
+          masterEdition: await getMasterEdition(asset),
           sysvarRent: SYSVAR_RENT_PUBKEY,
           tokenMetadataProgram: PROGRAM_ID,
           associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,

--- a/das_api/src/error.rs
+++ b/das_api/src/error.rs
@@ -12,7 +12,7 @@ pub enum DasApiError {
     PubkeyValidationError(String),
     #[error("Validation Error {0}")]
     ValidationError(String),
-    #[error("Database Error")]
+    #[error("Database Error {0}")]
     DatabaseError(#[from] sea_orm::DbErr),
 }
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,9 @@ services:
     depends_on:
       - redis
     restart: always
+    environment:
+      INGESTER_MESSENGER_CONFIG: '{redis_connection_str="redis://redis"}'
+      INGESTER_DATABASE_URL: 'postgres://solana:solana@db/solana'
     build:
       context: .
       dockerfile: Ingest.Dockerfile
@@ -41,6 +44,7 @@ services:
     - ./ledger:/config:rw
     environment:
       RUST_LOG: warn
+      PLUGIN_MESSENGER_CONFIG: '{redis_connection_str="redis://redis"}'
     ports:
       - "8900:8900"
       - "8001:8001"

--- a/docker/runs.sh
+++ b/docker/runs.sh
@@ -53,11 +53,11 @@ args=(
   --rpc-port 8899
   --bpf-program metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s /so/mpl_token_metadata.so
   --bpf-program BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY /so/bubblegum.so
-  --bpf-program Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS /so/gummyroll_crud.so
   --bpf-program GRoLLMza82AiYN7W9S9KCCtCyyPRAQP2ifBy4v4D5RMD /so/gummyroll.so
   --bpf-program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA /so/spl_token.so
   --bpf-program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb /so/spl_token_2022.so
   --bpf-program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL /so/spl_associated_token_account.so
+  --bpf-program WRAPYChf58WFCnyjXKJHtrPgzKXgHp6MD9aVDqJBbGh /so/candy_wrapper.so
   --geyser-plugin-config accountsdb-plugin-config.json
 )
 # shellcheck disable=SC2086

--- a/docker/runs.sh
+++ b/docker/runs.sh
@@ -20,7 +20,6 @@ cat << EOL > accountsdb-plugin-config.json
     "accounts_selector" : {
         "accounts" : [
             "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s",
-            "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
             "GRoLLMza82AiYN7W9S9KCCtCyyPRAQP2ifBy4v4D5RMD",
             "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
             "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
@@ -30,7 +29,6 @@ cat << EOL > accountsdb-plugin-config.json
     "transaction_selector" : {
         "mentions" : [
             "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s",
-            "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
             "GRoLLMza82AiYN7W9S9KCCtCyyPRAQP2ifBy4v4D5RMD",
             "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
             "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",

--- a/messenger/Cargo.toml
+++ b/messenger/Cargo.toml
@@ -14,6 +14,8 @@ redis = {version = "0.21.5", features = ["aio", "tokio-comp", "streams"], option
 log = "0.4.11"
 thiserror = "1.0.30"
 async-trait = "0.1.53"
+figment = "0.10.6"
+serde = "1.0.137"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/messenger/src/error.rs
+++ b/messenger/src/error.rs
@@ -2,6 +2,9 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum MessengerError {
+    #[error("Missing or invalid configuration: ({msg})")]
+    ConfigurationError { msg: String },
+
     #[error("Error creating connection: ({msg})")]
     ConnectionError { msg: String },
 

--- a/messenger/src/messenger.rs
+++ b/messenger/src/messenger.rs
@@ -1,4 +1,7 @@
-use {async_trait::async_trait, solana_geyser_plugin_interface::geyser_plugin_interface::Result};
+use figment::value::Dict;
+use serde::Deserialize;
+use {async_trait::async_trait};
+use crate::error::MessengerError;
 
 /// Some constants that can be used as stream key values.
 pub const ACCOUNT_STREAM: &str = "ACC";
@@ -8,12 +11,14 @@ pub const BLOCK_STREAM: &str = "BLK";
 
 #[async_trait]
 pub trait Messenger: Sync + Send {
-    async fn new() -> Result<Self>
+    async fn new(config: MessengerConfig) -> Result<Self, MessengerError>
     where
         Self: Sized;
 
     async fn add_stream(&mut self, stream_key: &'static str);
     async fn set_buffer_size(&mut self, stream_key: &'static str, max_buffer_size: usize);
-    async fn send(&mut self, stream_key: &'static str, bytes: &[u8]) -> Result<()>;
-    async fn recv(&mut self, stream_key: &'static str) -> Result<Vec<(i64, &[u8])>>;
+    async fn send(&mut self, stream_key: &'static str, bytes: &[u8]) -> Result<(), MessengerError>;
+    async fn recv(&mut self, stream_key: &'static str) -> Result<Vec<(i64, &[u8])>, MessengerError>;
 }
+
+pub type MessengerConfig = Dict;

--- a/nft_ingester/Cargo.toml
+++ b/nft_ingester/Cargo.toml
@@ -36,6 +36,7 @@ async-trait = "0.1.53"
 num-traits = "0.2.15"
 gummyroll = { path = "../contracts/programs/gummyroll", features = ["no-entrypoint"] }
 bubblegum = { path = "../contracts/programs/bubblegum", features = ["no-entrypoint"] }
+figment = { version = "0.10.6", features = ["env"] }
 
 [dependencies.num-integer]
 version = "0.1.44"

--- a/nft_ingester/src/error/mod.rs
+++ b/nft_ingester/src/error/mod.rs
@@ -21,6 +21,8 @@ pub enum IngesterError {
     DeserializationError(String),
     #[error("Task Manager Error {0}")]
     TaskManagerError(String),
+    #[error("Missing or invalid configuration: ({msg})")]
+    ConfigurationError { msg: String },
 
 }
 

--- a/nft_ingester/src/parsers/bubblegum.rs
+++ b/nft_ingester/src/parsers/bubblegum.rs
@@ -286,9 +286,9 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                 bubblegum::instruction::MintV1::deserialize(data_buf).unwrap();
             let accounts = instruction.accounts().unwrap();
             let update_authority = bytes_from_fb_table(keys, accounts[0] as usize);
-            let owner = bytes_from_fb_table(keys, accounts[3] as usize);
-            let delegate = bytes_from_fb_table(keys, accounts[4] as usize);
-            let merkle_slab = bytes_from_fb_table(keys, accounts[5] as usize);
+            let owner = bytes_from_fb_table(keys, accounts[4] as usize);
+            let delegate = bytes_from_fb_table(keys, accounts[5] as usize);
+            let merkle_slab = bytes_from_fb_table(keys, accounts[6] as usize);
             let metadata = ix.message.clone();
             let asset_data_id = db.transaction::<_, i64, IngesterError>(|txn| {
                 Box::pin(async move {

--- a/nft_ingester/src/parsers/gummyroll.rs
+++ b/nft_ingester/src/parsers/gummyroll.rs
@@ -120,10 +120,10 @@ pub async fn gummyroll_change_log_event_to_database(
     filling: bool
 ) -> Result<(), IngesterError> {
     let mut i: i64 = 0;
-    let depth = change_log_event.path.len() -1;
+    let depth = change_log_event.path.len() - 1;
     for p in change_log_event.path.into_iter() {
-        println!("index {} level {}, node {:?}", p.index , i, bs58::encode(p.node).into_string());
         let node_idx = p.index as i64;
+        println!("index {} level {}, node {:?}", p.index , i, bs58::encode(p.node).into_string());
         let tree_id = change_log_event.id.as_ref();
         let leaf_idx = if i == 0 {
             Some(node_idx_to_leaf_idx(node_idx ,depth as u32))

--- a/plerkle/Cargo.toml
+++ b/plerkle/Cargo.toml
@@ -37,6 +37,7 @@ messenger={path= "../messenger"}
 flatbuffers = "2.1.2"
 plerkle-serialization={path= "../plerkle_serialization"}
 tokio = { version = "1.17.0", features = ["full"] }
+figment = { version = "0.10.6", features = ["env"] }
 
 [dependencies.num-integer]
 version = "0.1.44"


### PR DESCRIPTION
In preparation for deploy to testnet I externalized the database and redis configuration to allow this to run in the cloud.

I also fixed an accounts ordering bug created with candy wrapper and a bug where the tests did not match the needed seeds for decompress.

ID == mint in NFT land on the v1 specification so I needed to make sure asset id is the passed in account for mint, and that mint authority (ephemeral) is a derived account from asset