### PR TITLE
Adding various docs to clarify structs / traits

### DIFF
--- a/contracts/programs/gummyroll/src/error.rs
+++ b/contracts/programs/gummyroll/src/error.rs
@@ -17,9 +17,7 @@ pub enum GummyrollError {
     #[msg("Issue zero copying concurrent merkle tree data")]
     ZeroCopyError,
 
-    /// The Gummyroll tree supports two configuration parameters: `max_depth` and `max_buffer_size`.
-    /// - `max_buffer_size` must be a power of 2; valid values are limited to `(8, 64, 256, 512, 1024, 2048)`
-    /// - `max_depth` can be any integer between 14 and 30.
+    /// See [MerkleRollHeader](/gummyroll/state/struct.MerkleRollHeader.html) for valid configuration options.
     #[msg("An unsupported max depth or max buffer size constant was provided")]
     MerkleRollConstantsError,
 

--- a/contracts/programs/gummyroll/src/error.rs
+++ b/contracts/programs/gummyroll/src/error.rs
@@ -1,16 +1,29 @@
 use anchor_lang::prelude::*;
 use concurrent_merkle_tree::error::CMTError;
 
+/// Errors related to misconfiguration or misuse of the Merkle tree
 #[error_code]
 pub enum GummyrollError {
+    /// This error is currently not used.
     #[msg("Incorrect leaf length. Expected vec of 32 bytes")]
     IncorrectLeafLength,
+
+    /// A modification to the tree was invalid and a changelog was not emitted.
+    /// The proof may be invalid or out-of-date, or the provided leaf hash was invalid.
     #[msg("Concurrent merkle tree error")]
     ConcurrentMerkleTreeError,
+
+    /// An issue was detected with loading the provided account data for this Gummyroll tree.
     #[msg("Issue zero copying concurrent merkle tree data")]
     ZeroCopyError,
+
+    /// The Gummyroll tree supports two configuration parameters: `max_depth` and `max_buffer_size`.
+    /// - `max_buffer_size` must be a power of 2; valid values are limited to `(8, 64, 256, 512, 1024, 2048)`
+    /// - `max_depth` can be any integer between 14 and 30.
     #[msg("An unsupported max depth or max buffer size constant was provided")]
     MerkleRollConstantsError,
+
+    /// When using Canopy, the stored byte length should a multiple of the node's byte length (32 bytes)
     #[msg("Expected a different byte length for the merkle roll canopy")]
     CanopyLengthMismatch,
 }

--- a/contracts/programs/gummyroll/src/state/mod.rs
+++ b/contracts/programs/gummyroll/src/state/mod.rs
@@ -69,16 +69,28 @@ impl<const MAX_DEPTH: usize> From<(Box<ChangeLog<MAX_DEPTH>>, Pubkey, u64)>
     }
 }
 
+/// Initialization parameters for a Gummyroll Merkle tree.
+///
+/// Only the following permutations are valid:
+///
+/// | max_depth | max_buffer_size       |
+/// | --------- | --------------------- |
+/// | 14        | (64, 256, 1024, 2048) |           
+/// | 20        | (64, 256, 1024, 2048) |           
+/// | 24        | (64, 256, 512, 1024, 2048) |           
+/// | 26        | (64, 256, 512, 1024, 2048) |           
+/// | 30        | (512, 1024, 2048) |           
+///
 #[derive(BorshDeserialize, BorshSerialize)]
 #[repr(C)]
 pub struct MerkleRollHeader {
-    /// Buffer of changelogs stored on-chain. Must be a power of 2;
-    /// Valid options limited to: `(8, 64, 256, 512, 1024, 2048)`
+    /// Buffer of changelogs stored on-chain.
+    /// Must be a power of 2; see above table for valid combinations.
     pub max_buffer_size: u32,
 
     /// Depth of the Merkle tree to store.
-    /// Valid options are any integer between 14-30
-    /// Tree capacity can be calculated as power(2, max_depth)
+    /// Tree capacity can be calculated as power(2, max_depth).
+    /// See above table for valid options.
     pub max_depth: u32,
 
     /// Authority that validates the content of the trees.
@@ -86,9 +98,11 @@ pub struct MerkleRollHeader {
     pub authority: Pubkey,
 
     /// Authority that is responsible for signing for new additions to the tree.
+    /// DEPRECATED: Likely to be removed!
     pub append_authority: Pubkey,
 
-    /// TODO(jon): Not sure what this is!
+    /// Slot corresponding to when the Merkle tree was created.
+    /// Provides a lower-bound on what slot to start (re-)building a tree from.
     pub creation_slot: u64,
 }
 

--- a/contracts/programs/gummyroll/src/utils.rs
+++ b/contracts/programs/gummyroll/src/utils.rs
@@ -1,8 +1,10 @@
+//! Various utilities for Gummyroll trees
+//!
+use crate::state::CandyWrapper;
 use anchor_lang::{
     prelude::*,
     solana_program::{msg, program::invoke, program_error::ProgramError},
 };
-use crate::state::CandyWrapper;
 use bytemuck::{Pod, PodCastError};
 use concurrent_merkle_tree::merkle_roll::MerkleRoll;
 use std::any::type_name;

--- a/lib/concurrent-merkle-tree/src/error.rs
+++ b/lib/concurrent-merkle-tree/src/error.rs
@@ -2,20 +2,35 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum CMTError {
+    /// Received an index larger than the rightmost index
     #[error("Received an index larger than the rightmost index")]
     LeafIndexOutOfBounds,
+
+    /// Invalid root recomputed from proof
     #[error("Invalid root recomputed from proof")]
     InvalidProof,
+
+    /// Node to append cannot be empty
     #[error("Cannot append an empty node")]
     CannotAppendEmptyNode,
+
+    /// The tree is at capacity
     #[error("Tree is full, cannot append")]
     TreeFull,
+
+    /// This tree has already been initialized
     #[error("Tree already initialized")]
     TreeAlreadyInitialized,
+
+    /// Invalid number of bytes passed for node (expected 32 bytes)
     #[error("Invalid number of bytes passed for node (expected 32 bytes)")]
     InvalidNodeByteLength,
+
+    /// Root not found in changelog buffer
     #[error("Root not found in changelog buffer")]
     RootNotFound,
+
+    /// Valid proof was passed to a leaf, but it's value has changed since the proof was issued
     #[error(
         "Valid proof was passed to a leaf, but it's value has changed since the proof was issued"
     )]

--- a/lib/concurrent-merkle-tree/src/error.rs
+++ b/lib/concurrent-merkle-tree/src/error.rs
@@ -26,7 +26,7 @@ pub enum CMTError {
     #[error("Invalid number of bytes passed for node (expected 32 bytes)")]
     InvalidNodeByteLength,
 
-    /// Root not found in changelog buffer
+    /// Fast forward error: we cannot find a valid point to fast-forward the current proof from
     #[error("Root not found in changelog buffer")]
     RootNotFound,
 


### PR DESCRIPTION
Intended to be viewed via `docs.rs`. Locally, run `cargo doc --open` to preview
