### PR TITLE
Fix Creators to Sum to 100 [Bubblegum, Gumball Machine, Sugar Shack]

### DIFF
--- a/contracts/programs/gumball-machine/src/utils.rs
+++ b/contracts/programs/gumball-machine/src/utils.rs
@@ -61,7 +61,7 @@ pub fn get_metadata_args(
         primary_sale_happened: true,
         is_mutable,
         edition_nonce: None,
-        token_standard: None,
+        token_standard: None, // TODO: set the correct token_standard here. NonFungibleEdition?
         collection: if collection == system_program_id {
             // Treat the SystemProgram as a the null case
             None

--- a/contracts/programs/sugar-shack/src/state/mod.rs
+++ b/contracts/programs/sugar-shack/src/state/mod.rs
@@ -7,7 +7,7 @@ pub struct MarketplaceProperties {
     pub authority: Pubkey,
     // The royalty percentage IN BASIS POINTS the marketplace will receive upon purchases through listings
     pub share: u16,
-    pub bump: u8
+    pub bump: u8,
 }
 
 // 8 bytes for discriminator + 32 byte pubkey + 1 share + 1 bump

--- a/contracts/sdk/gumball-machine/idl/gumball_machine.json
+++ b/contracts/sdk/gumball-machine/idl/gumball_machine.json
@@ -333,9 +333,29 @@
           }
         },
         {
+          "name": "receiver",
+          "type": {
+            "option": "publicKey"
+          }
+        },
+        {
           "name": "maxMintSize",
           "type": {
             "option": "u32"
+          }
+        },
+        {
+          "name": "creatorKeys",
+          "type": {
+            "option": {
+              "vec": "publicKey"
+            }
+          }
+        },
+        {
+          "name": "creatorShares",
+          "type": {
+            "option": "bytes"
           }
         }
       ]

--- a/contracts/sdk/gumball-machine/src/generated/instructions/updateHeaderMetadata.ts
+++ b/contracts/sdk/gumball-machine/src/generated/instructions/updateHeaderMetadata.ts
@@ -27,7 +27,10 @@ export type UpdateHeaderMetadataInstructionArgs = {
   goLiveDate: beet.COption<beet.bignum>
   botWallet: beet.COption<web3.PublicKey>
   authority: beet.COption<web3.PublicKey>
+  receiver: beet.COption<web3.PublicKey>
   maxMintSize: beet.COption<number>
+  creatorKeys: beet.COption<web3.PublicKey[]>
+  creatorShares: beet.COption<Uint8Array>
 }
 /**
  * @category Instructions
@@ -52,7 +55,10 @@ export const updateHeaderMetadataStruct = new beet.FixableBeetArgsStruct<
     ['goLiveDate', beet.coption(beet.i64)],
     ['botWallet', beet.coption(beetSolana.publicKey)],
     ['authority', beet.coption(beetSolana.publicKey)],
+    ['receiver', beet.coption(beetSolana.publicKey)],
     ['maxMintSize', beet.coption(beet.u32)],
+    ['creatorKeys', beet.coption(beet.array(beetSolana.publicKey))],
+    ['creatorShares', beet.coption(beet.bytes)],
   ],
   'UpdateHeaderMetadataInstructionArgs'
 )

--- a/contracts/sdk/indexer/smokeTest.ts
+++ b/contracts/sdk/indexer/smokeTest.ts
@@ -182,7 +182,7 @@ async function main() {
       }
       let k = Math.floor(Math.random() * assets.length);
       response = await fetch(
-        `${proofServerUrl}?leafHash=${assets[k].leafHash}&treeId=${assets[k].treeId}`,
+        `${proofServerUrl}?assetId=${assets[k].assetId}&treeId=${assets[k].treeId}`,
         { method: "GET" }
       );
       const proof = await response.json();

--- a/contracts/sdk/sugar-shack/idl/sugar_shack.json
+++ b/contracts/sdk/sugar-shack/idl/sugar_shack.json
@@ -251,7 +251,11 @@
     {
       "name": "purchase",
       "docs": [
-        "Enables any user to purchase an NFT listed on the marketplace."
+        "Enables any user to purchase an NFT listed on the marketplace.",
+        "@dev: To avoid overflow precision errors we generally avoid operations that would involve multiplying by f64s. (i.e. price * creator_share/100).",
+        "instead we compute the most smallest unit that could be paid out to an entity (a bip) and allocate bips via multiplication.",
+        "@notice: The risk here is that certain creators or the marketplace itself might not receive their fee, if price * num_bips_for_entity < 10,000.",
+        "@notice: Any fees not paid to creators/marketplace will be transferred to the lister."
       ],
       "accounts": [
         {
@@ -314,7 +318,7 @@
           "type": "u64"
         },
         {
-          "name": "dataHash",
+          "name": "metadataArgsHash",
           "type": {
             "array": [
               "u8",
@@ -342,6 +346,10 @@
         {
           "name": "creatorShares",
           "type": "bytes"
+        },
+        {
+          "name": "sellerFeeBasisPoints",
+          "type": "u16"
         }
       ]
     },

--- a/contracts/sdk/sugar-shack/src/generated/accounts/MarketplaceProperties.ts
+++ b/contracts/sdk/sugar-shack/src/generated/accounts/MarketplaceProperties.ts
@@ -20,9 +20,7 @@ export type MarketplacePropertiesArgs = {
   bump: number
 }
 
-export const marketplacePropertiesDiscriminator = [
-  31, 68, 0, 130, 46, 137, 61, 24,
-]
+const marketplacePropertiesDiscriminator = [31, 68, 0, 130, 46, 137, 61, 24]
 /**
  * Holds the data for the {@link MarketplaceProperties} Account and provides de/serialization
  * functionality for that data

--- a/contracts/sdk/sugar-shack/src/generated/instructions/purchase.ts
+++ b/contracts/sdk/sugar-shack/src/generated/instructions/purchase.ts
@@ -15,11 +15,12 @@ import * as web3 from '@solana/web3.js'
  */
 export type PurchaseInstructionArgs = {
   price: beet.bignum
-  dataHash: number[] /* size: 32 */
+  metadataArgsHash: number[] /* size: 32 */
   nonce: beet.bignum
   index: number
   root: number[] /* size: 32 */
   creatorShares: Uint8Array
+  sellerFeeBasisPoints: number
 }
 /**
  * @category Instructions
@@ -34,11 +35,12 @@ export const purchaseStruct = new beet.FixableBeetArgsStruct<
   [
     ['instructionDiscriminator', beet.uniformFixedSizeArray(beet.u8, 8)],
     ['price', beet.u64],
-    ['dataHash', beet.uniformFixedSizeArray(beet.u8, 32)],
+    ['metadataArgsHash', beet.uniformFixedSizeArray(beet.u8, 32)],
     ['nonce', beet.u64],
     ['index', beet.u32],
     ['root', beet.uniformFixedSizeArray(beet.u8, 32)],
     ['creatorShares', beet.bytes],
+    ['sellerFeeBasisPoints', beet.u16],
   ],
   'PurchaseInstructionArgs'
 )

--- a/contracts/tests/bubblegum-test-rpc.ts
+++ b/contracts/tests/bubblegum-test-rpc.ts
@@ -1,10 +1,10 @@
 import * as anchor from "@project-serum/anchor";
-import {keccak_256} from "js-sha3";
-import {BN, Provider, Program} from "@project-serum/anchor";
-import {Bubblegum} from "../target/types/bubblegum";
-import {Gummyroll} from "../target/types/gummyroll";
+import { keccak_256 } from "js-sha3";
+import { BN, Provider, Program } from "@project-serum/anchor";
+import { Bubblegum } from "../target/types/bubblegum";
+import { Gummyroll } from "../target/types/gummyroll";
 import fetch from "node-fetch";
-import {PROGRAM_ID} from "@metaplex-foundation/mpl-token-metadata";
+import { PROGRAM_ID } from "@metaplex-foundation/mpl-token-metadata";
 import {
   PublicKey,
   Keypair,
@@ -13,7 +13,7 @@ import {
   Connection as web3Connection,
   SYSVAR_RENT_PUBKEY, AccountMeta,
 } from "@solana/web3.js";
-import {assert} from "chai";
+import { assert } from "chai";
 import {
   createMintV1Instruction,
   createDecompressV1Instruction,
@@ -24,7 +24,7 @@ import {
   createCreateTreeInstruction
 } from "../sdk/bubblegum/src/generated";
 
-import {buildTree, checkProof, Tree} from "./merkle-tree";
+import { buildTree, checkProof, Tree } from "./merkle-tree";
 import {
   decodeMerkleRoll,
   getMerkleRollAccountSize,
@@ -37,28 +37,19 @@ import {
   TOKEN_PROGRAM_ID,
   Token,
 } from "@solana/spl-token";
-import {execute, logTx} from "./utils";
-import {TokenProgramVersion, Version} from "../sdk/bubblegum/src/generated";
-import {sleep} from "@metaplex-foundation/amman/dist/utils";
-import {verbose} from "sqlite3";
-import {bs58} from "@project-serum/anchor/dist/cjs/utils/bytes";
-import {CANDY_WRAPPER_PROGRAM_ID} from "../sdk/utils";
+import { execute, logTx, num16ToBuffer, bufferToArray } from "./utils";
+import { TokenProgramVersion, Version } from "../sdk/bubblegum/src/generated";
+import { sleep } from "@metaplex-foundation/amman/dist/utils";
+import { verbose } from "sqlite3";
+import { bs58 } from "@project-serum/anchor/dist/cjs/utils/bytes";
+import { CANDY_WRAPPER_PROGRAM_ID } from "../sdk/utils";
 
 // @ts-ignore
 let Bubblegum;
 // @ts-ignore
 let GummyrollProgramId;
 
-/// Converts to Uint8Array
-function bufferToArray(buffer: Buffer): number[] {
-  const nums = [];
-  for (let i = 0; i < buffer.length; i++) {
-    nums.push(buffer.at(i));
-  }
-  return nums;
-}
-
-interface TreeProof  {
+interface TreeProof {
   root: string,
   proof: AccountMeta[]
 }
@@ -66,7 +57,7 @@ interface TreeProof  {
 async function getProof(asset: PublicKey): Promise<TreeProof> {
   let resp = await fetch("http://localhost:9090", {
     method: 'POST',
-    headers: {'Content-Type': 'application/json'},
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       jsonrpc: "2.0", id: "stupid", method: "get_asset_proof", params: [asset.toBase58()]
     })
@@ -229,7 +220,7 @@ describe("bubblegum", () => {
             delegate: payer.publicKey,
             merkleSlab: merkleRollKeypair.publicKey,
           },
-          {message: metadata}
+          { message: metadata }
         );
         console.log(" - Minting to tree");
         const mintTx = await Bubblegum.provider.send(
@@ -240,8 +231,12 @@ describe("bubblegum", () => {
             commitment: "confirmed",
           }
         );
+        const metadataArgsBuffer = mintIx.data.slice(8)
+        const metadataArgsHash = keccak_256.digest(metadataArgsBuffer);
+        const sellerFeeBasisPointsNumberArray = bufferToArray(num16ToBuffer(metadata.sellerFeeBasisPoints))
+        const allDataToHash = metadataArgsHash.concat(sellerFeeBasisPointsNumberArray)
         const dataHash = bufferToArray(
-          Buffer.from(keccak_256.digest(mintIx.data.slice(8)))
+          Buffer.from(keccak_256.digest(allDataToHash))
         );
         const creatorHash = bufferToArray(Buffer.from(keccak_256.digest([])));
 
@@ -257,7 +252,7 @@ describe("bubblegum", () => {
           Bubblegum.programId
         );
         {
-          let {root, proof} = await getProof(asset);
+          let { root, proof } = await getProof(asset);
           let transferIx = createTransferInstruction(
             {
               authority: treeAuthority,
@@ -284,7 +279,7 @@ describe("bubblegum", () => {
 
         console.log(" - Delegating Ownership");
         {
-          let {root, proof} = await getProof(asset);
+          let { root, proof } = await getProof(asset);
           let delegateIx = await createDelegateInstruction(
             {
               authority: treeAuthority,
@@ -309,7 +304,7 @@ describe("bubblegum", () => {
 
         console.log(" - Transferring Ownership (through delegate)");
         {
-          let {root, proof} = await getProof(asset);
+          let { root, proof } = await getProof(asset);
           let delTransferIx = createTransferInstruction(
             {
               authority: treeAuthority,
@@ -351,7 +346,7 @@ describe("bubblegum", () => {
         if (i % 2 == 0) {
           console.log(" - Redeeming Leaf", voucher.toBase58());
           {
-            let {root, proof} = await getProof(asset);
+            let { root, proof } = await getProof(asset);
             let redeemIx = createRedeemInstruction(
               {
                 authority: treeAuthority,
@@ -387,8 +382,8 @@ describe("bubblegum", () => {
                 merkleRollKeypair.publicKey
               );
             let merkleRoll = decodeMerkleRoll(merkleRollAccount.data);
-            let {root, proof} = await getProof(asset);
-           console.log("rpc root ", root);
+            let { root, proof } = await getProof(asset);
+            console.log("rpc root ", root);
 
 
             console.log("on chain roots ")
@@ -419,7 +414,7 @@ describe("bubblegum", () => {
 
           console.log(" - Decompressing leaf");
           {
-            let {root, proof} = await getProof(asset);
+            let { root, proof } = await getProof(asset);
             let redeemIx = createRedeemInstruction(
               {
                 authority: treeAuthority,

--- a/contracts/tests/bubblegum-test.ts
+++ b/contracts/tests/bubblegum-test.ts
@@ -38,7 +38,7 @@ import {
   TOKEN_PROGRAM_ID,
   Token,
 } from "@solana/spl-token";
-import { bufferToArray, execute } from "./utils";
+import { bufferToArray, execute, num16ToBuffer } from "./utils";
 import { TokenProgramVersion, Version } from "../sdk/bubblegum/src/generated";
 import { CANDY_WRAPPER_PROGRAM_ID } from "../sdk/utils";
 import { getBubblegumAuthorityPDA, getCreateTreeIxs, getNonceCount, getVoucherPDA } from "../sdk/bubblegum/src/convenience";
@@ -168,8 +168,12 @@ describe("bubblegum", () => {
           commitment: "confirmed",
         }
       );
+      const metadataArgsBuffer = mintIx.data.slice(8)
+      const metadataArgsHash = keccak_256.digest(metadataArgsBuffer);
+      const sellerFeeBasisPointsNumberArray = bufferToArray(num16ToBuffer(metadata.sellerFeeBasisPoints))
+      const allDataToHash = metadataArgsHash.concat(sellerFeeBasisPointsNumberArray)
       const dataHash = bufferToArray(
-        Buffer.from(keccak_256.digest(mintIx.data.slice(8)))
+        Buffer.from(keccak_256.digest(allDataToHash))
       );
       const creatorHash = bufferToArray(Buffer.from(keccak_256.digest([])));
       let onChainRoot = await getRootOfOnChainMerkleRoot(connection, merkleRollKeypair.publicKey);

--- a/contracts/tests/gumball-machine-test.ts
+++ b/contracts/tests/gumball-machine-test.ts
@@ -165,7 +165,7 @@ describe("gumball-machine", () => {
       // Check that creator matches user specification
       if (i < expectedHeader.creators.length) {
         assert(
-          gm.header.creators[i].address.equals(gm.header.creators[i].address),
+          gm.header.creators[i].address.equals(expectedHeader.creators[i].address),
           "Gumball Machine creator has mismatching address"
         );
         assert(
@@ -285,12 +285,11 @@ describe("gumball-machine", () => {
       let c: GumballCreatorAdapter = {
         address: gumballMachineInitArgs.creatorKeys[i],
         share: gumballMachineInitArgs.creatorShares[i],
-        verified: 1
+        verified: 0
       }
       expectedCreators.push(c);
     }
     gumballMachineInitArgs.creatorKeys
-    let c: GumballCreatorAdapter = { address: Keypair.generate().publicKey, verified: 1, share: 1 };
     let expectedOnChainHeader: GumballMachineHeader = {
       urlBase: gumballMachineInitArgs.urlBase,
       nameBase: gumballMachineInitArgs.nameBase,
@@ -600,7 +599,7 @@ describe("gumball-machine", () => {
         merkleRollKeypair = Keypair.generate();
         exampleAdditionalSecondarySaleRoyaltyRecipient = Keypair.generate();
         creatorKeys = [creatorPaymentWallet.publicKey, exampleAdditionalSecondarySaleRoyaltyRecipient.publicKey];
-        creatorShares = Uint8Array.from([1, 5]);
+        creatorShares = Uint8Array.from([10, 90]);
 
         baseGumballMachineInitProps = {
           maxDepth: 3,
@@ -838,18 +837,11 @@ describe("gumball-machine", () => {
             goLiveDate: new BN(5678.0),
             botWallet: Keypair.generate().publicKey,
             authority: Keypair.generate().publicKey,
+            receiver: Keypair.generate().publicKey,
             maxMintSize: 15,
+            creatorKeys: [],
+            creatorShares: Uint8Array.from([])
           };
-
-          let expectedCreators = [];
-          for (let i = 0; i < creatorKeys.length; i++) {
-            let c: GumballCreatorAdapter = {
-              address: creatorKeys[i],
-              share: creatorShares[i],
-              verified: 1
-            }
-            expectedCreators.push(c);
-          }
           const expectedOnChainHeader: GumballMachineHeader = {
             urlBase: newGumballMachineHeader.urlBase,
             nameBase: newGumballMachineHeader.nameBase,
@@ -858,13 +850,13 @@ describe("gumball-machine", () => {
             sellerFeeBasisPoints: newGumballMachineHeader.sellerFeeBasisPoints,
             isMutable: newGumballMachineHeader.isMutable ? 1 : 0,
             retainAuthority: newGumballMachineHeader.retainAuthority ? 1 : 0,
-            creators: expectedCreators,
+            creators: [],
             padding: [0],
             price: newGumballMachineHeader.price,
             goLiveDate: newGumballMachineHeader.goLiveDate,
             mint: NATIVE_MINT,
             botWallet: newGumballMachineHeader.botWallet,
-            receiver: baseGumballMachineInitProps.receiver,
+            receiver: newGumballMachineHeader.receiver,
             authority: newGumballMachineHeader.authority,
             collectionKey: baseGumballMachineInitProps.collectionKey,
             extensionLen: baseGumballMachineInitProps.extensionLen,
@@ -933,7 +925,7 @@ describe("gumball-machine", () => {
         );
 
         creatorKeys = [creatorReceiverTokenAccount.address];
-        creatorShares = Uint8Array.from([1]);
+        creatorShares = Uint8Array.from([100]);
 
         baseGumballMachineInitProps = {
           maxDepth: 3,
@@ -1140,7 +1132,7 @@ describe("gumball-machine", () => {
         merkleRollKeypair = Keypair.generate();
         exampleAdditionalSecondarySaleRoyaltyRecipient = Keypair.generate();
         creatorKeys = [creatorPaymentWallet.publicKey, exampleAdditionalSecondarySaleRoyaltyRecipient.publicKey];
-        creatorShares = Uint8Array.from([1, 5]);
+        creatorShares = Uint8Array.from([10, 90]);
 
         baseGumballMachineInitProps = {
           maxDepth: 5,
@@ -1250,6 +1242,9 @@ describe("gumball-machine", () => {
       });
       describe("admin instructions", async () => {
         it("Can update gumball header", async () => {
+          const newCreatorKeys = [Keypair.generate().publicKey, Keypair.generate().publicKey, Keypair.generate().publicKey];
+          const newCreatorShares = Uint8Array.from([50, 25, 25]);
+
           const newGumballMachineHeader: UpdateHeaderMetadataInstructionArgs = {
             urlBase: strToByteArray("https://arweave.net", 64),
             nameBase: strToByteArray("GUMBALL", 32),
@@ -1262,15 +1257,18 @@ describe("gumball-machine", () => {
             goLiveDate: new BN(5678.0),
             botWallet: Keypair.generate().publicKey,
             authority: Keypair.generate().publicKey,
+            receiver: Keypair.generate().publicKey,
             maxMintSize: 15,
+            creatorKeys: newCreatorKeys,
+            creatorShares: newCreatorShares
           };
 
           let expectedCreators = [];
-          for (let i = 0; i < creatorKeys.length; i++) {
+          for (let i = 0; i < newCreatorKeys.length; i++) {
             let c: GumballCreatorAdapter = {
-              address: creatorKeys[i],
-              share: creatorShares[i],
-              verified: 1
+              address: newCreatorKeys[i],
+              share: newCreatorShares[i],
+              verified: 0
             }
             expectedCreators.push(c);
           }
@@ -1288,7 +1286,7 @@ describe("gumball-machine", () => {
             goLiveDate: newGumballMachineHeader.goLiveDate,
             mint: NATIVE_MINT,
             botWallet: newGumballMachineHeader.botWallet,
-            receiver: baseGumballMachineInitProps.receiver,
+            receiver: newGumballMachineHeader.receiver,
             authority: newGumballMachineHeader.authority,
             collectionKey: baseGumballMachineInitProps.collectionKey,
             extensionLen: baseGumballMachineInitProps.extensionLen,

--- a/contracts/tests/utils.ts
+++ b/contracts/tests/utils.ts
@@ -32,15 +32,23 @@ export async function execute(
 /// Convert a 32 bit number to a buffer of bytes
 export function num32ToBuffer(num: number) {
   const isU32 = (num >= 0 && num < Math.pow(2, 32));
-  const isI32 = (num >= -1 * Math.pow(2, 31) && num < Math.pow(2, 31))
-  if (!isU32 || !isI32) {
+  if (!isU32) {
     throw new Error("Attempted to convert non 32 bit integer to byte array")
   }
-  var byte1 = 0xff & num;
-  var byte2 = 0xff & (num >> 8);
-  var byte3 = 0xff & (num >> 16);
-  var byte4 = 0xff & (num >> 24);
-  return Buffer.from([byte1, byte2, byte3, byte4])
+  const b = Buffer.alloc(4);
+  b.writeInt32LE(num);
+  return b;
+}
+
+/// Convert a 16 bit number to a buffer of bytes
+export function num16ToBuffer(num: number) {
+  const isU16 = (num >= 0 && num < Math.pow(2, 16));
+  if (!isU16) {
+    throw new Error("Attempted to convert non 16 bit integer to byte array")
+  }
+  const b = Buffer.alloc(2);
+  b.writeUInt16LE(num);
+  return b;
 }
 
 /// Check if two Array types contain the same values in order


### PR DESCRIPTION
Creator shares need to sum to 100 (if creators are specified) for Bubblegum protocol NFTs to be interoperable with Metaplex (decompress). Our current model was not interpreting creators in this way. Our current model interpreted creators as some, potentially zero-sized, array of creators which would each have some small share (1%, 2%, etc.) which represented a share in the total purchase price of the NFT that they would be alloted as a royalty. We've now changed this to match the Metaplex model where the sum of all creator shares adds to 100, but the total royalty amount paid our corresponds to `seller_fee_basis_points`. See changes to sugar shack for more details.

This PR also enables gumball machine authorities to update their receiver and creator header fields, and raises some questions about other fields that are currently updateable.