### PR TITLE
[WIP] Adding seq number to Plerkle asset tables (new PR)

### DIFF
--- a/digital_asset_types/src/dao/asset.rs
+++ b/digital_asset_types/src/dao/asset.rs
@@ -35,6 +35,7 @@ pub struct Model {
     pub chain_data_id: Option<i64>,
     pub created_at: Option<DateTimeWithTimeZone>,
     pub burnt: bool,
+    pub seq: i64,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -58,6 +59,7 @@ pub enum Column {
     ChainDataId,
     CreatedAt,
     Burnt,
+    Seq,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -103,6 +105,7 @@ impl ColumnTrait for Column {
             Self::ChainDataId => ColumnType::BigInteger.def().null(),
             Self::CreatedAt => ColumnType::TimestampWithTimeZone.def().null(),
             Self::Burnt => ColumnType::Boolean.def(),
+            Self::Seq => ColumnType::BigInteger.def(),
         }
     }
 }

--- a/digital_asset_types/src/dao/asset.rs
+++ b/digital_asset_types/src/dao/asset.rs
@@ -35,7 +35,12 @@ pub struct Model {
     pub chain_data_id: Option<i64>,
     pub created_at: Option<DateTimeWithTimeZone>,
     pub burnt: bool,
-    pub seq: i64,
+    pub bgum_tx_seq: Option<i64>,
+    pub bgum_burn_seq: Option<i64>,
+    pub bgum_delegate_seq: Option<i64>,
+    pub bgum_mint_seq: Option<i64>,
+    pub bgum_redeem_seq: Option<i64>,
+    pub bgum_cx_redeem_seq: Option<i64>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -59,7 +64,12 @@ pub enum Column {
     ChainDataId,
     CreatedAt,
     Burnt,
-    Seq,
+    BgumTxSeq,
+    BgumBurnSeq,
+    BgumDelegateSeq,
+    BgumMintSeq,
+    BgumRedeemSeq,
+    BgumCxRedeemSeq,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -105,7 +115,12 @@ impl ColumnTrait for Column {
             Self::ChainDataId => ColumnType::BigInteger.def().null(),
             Self::CreatedAt => ColumnType::TimestampWithTimeZone.def().null(),
             Self::Burnt => ColumnType::Boolean.def(),
-            Self::Seq => ColumnType::BigInteger.def(),
+            Self::BgumTxSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumBurnSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumDelegateSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumMintSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumRedeemSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumCxRedeemSeq => ColumnType::BigInteger.def().null(),
         }
     }
 }

--- a/digital_asset_types/src/dao/asset_authority.rs
+++ b/digital_asset_types/src/dao/asset_authority.rs
@@ -18,6 +18,7 @@ pub struct Model {
     pub asset_id: Vec<u8>,
     pub scopes: Option<String>,
     pub authority: Vec<u8>,
+    pub seq: i64,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -26,6 +27,7 @@ pub enum Column {
     AssetId,
     Scopes,
     Authority,
+    Seq,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -53,6 +55,7 @@ impl ColumnTrait for Column {
             Self::AssetId => ColumnType::Binary.def(),
             Self::Scopes => ColumnType::Custom("array".to_owned()).def().null(),
             Self::Authority => ColumnType::Binary.def(),
+            Self::Seq => ColumnType::BigInteger.def(),
         }
     }
 }

--- a/digital_asset_types/src/dao/asset_authority.rs
+++ b/digital_asset_types/src/dao/asset_authority.rs
@@ -18,7 +18,12 @@ pub struct Model {
     pub asset_id: Vec<u8>,
     pub scopes: Option<String>,
     pub authority: Vec<u8>,
-    pub seq: i64,
+    pub bgum_tx_seq: Option<i64>,
+    pub bgum_burn_seq: Option<i64>,
+    pub bgum_delegate_seq: Option<i64>,
+    pub bgum_mint_seq: Option<i64>,
+    pub bgum_redeem_seq: Option<i64>,
+    pub bgum_cx_redeem_seq: Option<i64>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -27,7 +32,12 @@ pub enum Column {
     AssetId,
     Scopes,
     Authority,
-    Seq,
+    BgumTxSeq,
+    BgumBurnSeq,
+    BgumDelegateSeq,
+    BgumMintSeq,
+    BgumRedeemSeq,
+    BgumCxRedeemSeq,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -55,7 +65,12 @@ impl ColumnTrait for Column {
             Self::AssetId => ColumnType::Binary.def(),
             Self::Scopes => ColumnType::Custom("array".to_owned()).def().null(),
             Self::Authority => ColumnType::Binary.def(),
-            Self::Seq => ColumnType::BigInteger.def(),
+            Self::BgumTxSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumBurnSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumDelegateSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumMintSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumRedeemSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumCxRedeemSeq => ColumnType::BigInteger.def().null(),
         }
     }
 }

--- a/digital_asset_types/src/dao/asset_creators.rs
+++ b/digital_asset_types/src/dao/asset_creators.rs
@@ -19,6 +19,7 @@ pub struct Model {
     pub creator: Vec<u8>,
     pub share: i32,
     pub verified: bool,
+    pub seq: i64,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -28,6 +29,7 @@ pub enum Column {
     Creator,
     Share,
     Verified,
+    Seq,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -56,6 +58,7 @@ impl ColumnTrait for Column {
             Self::Creator => ColumnType::Binary.def(),
             Self::Share => ColumnType::Integer.def(),
             Self::Verified => ColumnType::Boolean.def(),
+            Self::Seq => ColumnType::BigInteger.def(),
         }
     }
 }

--- a/digital_asset_types/src/dao/asset_creators.rs
+++ b/digital_asset_types/src/dao/asset_creators.rs
@@ -19,7 +19,12 @@ pub struct Model {
     pub creator: Vec<u8>,
     pub share: i32,
     pub verified: bool,
-    pub seq: i64,
+    pub bgum_tx_seq: Option<i64>,
+    pub bgum_burn_seq: Option<i64>,
+    pub bgum_delegate_seq: Option<i64>,
+    pub bgum_mint_seq: Option<i64>,
+    pub bgum_redeem_seq: Option<i64>,
+    pub bgum_cx_redeem_seq: Option<i64>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -29,7 +34,12 @@ pub enum Column {
     Creator,
     Share,
     Verified,
-    Seq,
+    BgumTxSeq,
+    BgumBurnSeq,
+    BgumDelegateSeq,
+    BgumMintSeq,
+    BgumRedeemSeq,
+    BgumCxRedeemSeq,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -58,7 +68,12 @@ impl ColumnTrait for Column {
             Self::Creator => ColumnType::Binary.def(),
             Self::Share => ColumnType::Integer.def(),
             Self::Verified => ColumnType::Boolean.def(),
-            Self::Seq => ColumnType::BigInteger.def(),
+            Self::BgumTxSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumBurnSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumDelegateSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumMintSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumRedeemSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumCxRedeemSeq => ColumnType::BigInteger.def().null(),
         }
     }
 }

--- a/digital_asset_types/src/dao/asset_grouping.rs
+++ b/digital_asset_types/src/dao/asset_grouping.rs
@@ -18,7 +18,12 @@ pub struct Model {
     pub asset_id: Vec<u8>,
     pub group_key: String,
     pub group_value: String,
-    pub seq: i64,
+    pub bgum_tx_seq: Option<i64>,
+    pub bgum_burn_seq: Option<i64>,
+    pub bgum_delegate_seq: Option<i64>,
+    pub bgum_mint_seq: Option<i64>,
+    pub bgum_redeem_seq: Option<i64>,
+    pub bgum_cx_redeem_seq: Option<i64>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -27,7 +32,12 @@ pub enum Column {
     AssetId,
     GroupKey,
     GroupValue,
-    Seq,
+    BgumTxSeq,
+    BgumBurnSeq,
+    BgumDelegateSeq,
+    BgumMintSeq,
+    BgumRedeemSeq,
+    BgumCxRedeemSeq,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -55,7 +65,12 @@ impl ColumnTrait for Column {
             Self::AssetId => ColumnType::Binary.def(),
             Self::GroupKey => ColumnType::Text.def(),
             Self::GroupValue => ColumnType::Text.def(),
-            Self::Seq => ColumnType::BigInteger.def(),
+            Self::BgumTxSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumBurnSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumDelegateSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumMintSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumRedeemSeq => ColumnType::BigInteger.def().null(),
+            Self::BgumCxRedeemSeq => ColumnType::BigInteger.def().null(),
         }
     }
 }

--- a/digital_asset_types/src/dao/asset_grouping.rs
+++ b/digital_asset_types/src/dao/asset_grouping.rs
@@ -18,6 +18,7 @@ pub struct Model {
     pub asset_id: Vec<u8>,
     pub group_key: String,
     pub group_value: String,
+    pub seq: i64,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -26,6 +27,7 @@ pub enum Column {
     AssetId,
     GroupKey,
     GroupValue,
+    Seq,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -53,6 +55,7 @@ impl ColumnTrait for Column {
             Self::AssetId => ColumnType::Binary.def(),
             Self::GroupKey => ColumnType::Text.def(),
             Self::GroupValue => ColumnType::Text.def(),
+            Self::Seq => ColumnType::BigInteger.def(),
         }
     }
 }

--- a/digital_asset_types/src/dao/sea_orm_active_enums.rs
+++ b/digital_asset_types/src/dao/sea_orm_active_enums.rs
@@ -4,6 +4,22 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(
+    rs_type = "String",
+    db_type = "Enum",
+    enum_name = "royalty_target_type"
+)]
+pub enum RoyaltyTargetType {
+    #[sea_orm(string_value = "creators")]
+    Creators,
+    #[sea_orm(string_value = "fanout")]
+    Fanout,
+    #[sea_orm(string_value = "single")]
+    Single,
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "chain_mutability")]
 pub enum ChainMutability {
     #[sea_orm(string_value = "immutable")]
@@ -30,22 +46,6 @@ pub enum OwnerType {
     Single,
     #[sea_orm(string_value = "token")]
     Token,
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(
-    rs_type = "String",
-    db_type = "Enum",
-    enum_name = "royalty_target_type"
-)]
-pub enum RoyaltyTargetType {
-    #[sea_orm(string_value = "creators")]
-    Creators,
-    #[sea_orm(string_value = "fanout")]
-    Fanout,
-    #[sea_orm(string_value = "single")]
-    Single,
     #[sea_orm(string_value = "unknown")]
     Unknown,
 }

--- a/digital_asset_types/src/dao/sea_orm_active_enums.rs
+++ b/digital_asset_types/src/dao/sea_orm_active_enums.rs
@@ -20,6 +20,16 @@ pub enum RoyaltyTargetType {
     Unknown,
 }
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "owner_type")]
+pub enum OwnerType {
+    #[sea_orm(string_value = "single")]
+    Single,
+    #[sea_orm(string_value = "token")]
+    Token,
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "chain_mutability")]
 pub enum ChainMutability {
     #[sea_orm(string_value = "immutable")]
@@ -36,16 +46,6 @@ pub enum Mutability {
     Immutable,
     #[sea_orm(string_value = "mutable")]
     Mutable,
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "owner_type")]
-pub enum OwnerType {
-    #[sea_orm(string_value = "single")]
-    Single,
-    #[sea_orm(string_value = "token")]
-    Token,
     #[sea_orm(string_value = "unknown")]
     Unknown,
 }

--- a/init.sql
+++ b/init.sql
@@ -109,7 +109,8 @@ create table asset
     chain_data_id         bigint references asset_data (id),
     -- visibility
     created_at            timestamp with time zone     default (now() at time zone 'utc'),
-    burnt                 bool                not null default false
+    burnt                 bool                not null default false,
+    seq                   bigint              not null
 );
 
 create index asset_tree on asset (tree_id);
@@ -125,7 +126,8 @@ create table asset_grouping
     id          bigserial PRIMARY KEY,
     asset_id    bytea references asset (id) not null,
     group_key   text                        not null,
-    group_value text                        not null
+    group_value text                        not null,
+    seq         bigint                      not null
 );
 -- Limit indexable grouping keys, meaning only create on specific keys, but index the ones we allow
 create index asset_grouping_key on asset_grouping (group_key, group_value);
@@ -137,7 +139,8 @@ create table asset_authority
     id        bigserial PRIMARY KEY,
     asset_id  bytea references asset (id) not null,
     scopes    text[],
-    authority bytea                       not null
+    authority bytea                       not null,
+    seq       bigint                      not null
 );
 create index asset_authority_idx on asset_authority (asset_id, authority);
 
@@ -148,9 +151,9 @@ create table asset_creators
     asset_id bytea references asset (id) not null,
     creator  bytea                       not null,
     share    int                         not null default 0,
-    verified bool                        not null default false
+    verified bool                        not null default false,
+    seq      bigint                      not null
 );
-
 
 create index asset_creator on asset_creators (asset_id, creator);
 create index asset_verified_creator on asset_creators (asset_id, verified);

--- a/init.sql
+++ b/init.sql
@@ -110,7 +110,12 @@ create table asset
     -- visibility
     created_at            timestamp with time zone     default (now() at time zone 'utc'),
     burnt                 bool                not null default false,
-    seq                   bigint              not null
+    bgum_tx_seq           bigint,
+    bgum_burn_seq         bigint,
+    bgum_delegate_seq     bigint,
+    bgum_mint_seq         bigint,
+    bgum_redeem_seq       bigint,
+    bgum_cx_redeem_seq    bigint
 );
 
 create index asset_tree on asset (tree_id);
@@ -123,11 +128,16 @@ create index asset_delegate on asset (delegate);
 -- grouping
 create table asset_grouping
 (
-    id          bigserial PRIMARY KEY,
-    asset_id    bytea references asset (id) not null,
-    group_key   text                        not null,
-    group_value text                        not null,
-    seq         bigint                      not null
+    id                    bigserial PRIMARY KEY,
+    asset_id              bytea references asset (id) not null,
+    group_key             text                        not null,
+    group_value           text                        not null,
+    bgum_tx_seq           bigint,
+    bgum_burn_seq         bigint,
+    bgum_delegate_seq     bigint,
+    bgum_mint_seq         bigint,
+    bgum_redeem_seq       bigint,
+    bgum_cx_redeem_seq    bigint
 );
 -- Limit indexable grouping keys, meaning only create on specific keys, but index the ones we allow
 create index asset_grouping_key on asset_grouping (group_key, group_value);
@@ -136,23 +146,33 @@ create index asset_grouping_value on asset_grouping (group_key, asset_id);
 -- authority
 create table asset_authority
 (
-    id        bigserial PRIMARY KEY,
-    asset_id  bytea references asset (id) not null,
-    scopes    text[],
-    authority bytea                       not null,
-    seq       bigint                      not null
+    id                    bigserial PRIMARY KEY,
+    asset_id              bytea references asset (id) not null,
+    scopes                text[],
+    authority             bytea                       not null,
+    bgum_tx_seq           bigint,
+    bgum_burn_seq         bigint,
+    bgum_delegate_seq     bigint,
+    bgum_mint_seq         bigint,
+    bgum_redeem_seq       bigint,
+    bgum_cx_redeem_seq    bigint
 );
 create index asset_authority_idx on asset_authority (asset_id, authority);
 
 -- creators
 create table asset_creators
 (
-    id       bigserial PRIMARY KEY,
-    asset_id bytea references asset (id) not null,
-    creator  bytea                       not null,
-    share    int                         not null default 0,
-    verified bool                        not null default false,
-    seq      bigint                      not null
+    id                    bigserial PRIMARY KEY,
+    asset_id              bytea references asset (id) not null,
+    creator               bytea                       not null,
+    share                 int                 not null default 0,
+    verified              bool                not null default false,
+    bgum_tx_seq           bigint,
+    bgum_burn_seq         bigint,
+    bgum_delegate_seq     bigint,
+    bgum_mint_seq         bigint,
+    bgum_redeem_seq       bigint,
+    bgum_cx_redeem_seq    bigint
 );
 
 create index asset_creator on asset_creators (asset_id, creator);

--- a/nft_ingester/src/main.rs
+++ b/nft_ingester/src/main.rs
@@ -182,7 +182,7 @@ async fn _handle_account(manager: &ProgramHandlerManager<'static>, data: Vec<(i6
 
 async fn handle_transaction(manager: &ProgramHandlerManager<'static>, data: Vec<(i64, &[u8])>) {
     for (message_id, data) in data {
-        println!("RECV");
+        println!("RECV, data size: {}", data.len());
         //TODO -> Dedupe the stream, the stream could have duplicates as a way of ensuring fault tolerance if one validator node goes down.
         //  Possible solution is dedup on the plerkle side but this doesnt follow our principle of getting messages out of the validator asd fast as possible.
         //  Consider a Messenger Implementation detail the deduping of whats in this stream so that


### PR DESCRIPTION
### This doesn't work

### Notes
- Needed to support replaying of Bubblegum instructions
and avoid putting old data in various asset tables.
- Modifying `INSERT` statements for Bubblegum Mint
instructions to have `ON_CONFLICT` and `WHERE` clauses
that check `seq` for each bubblegum command.
- Modifying `UPDATE` statements for other Bubblegum
instructions to have `WHERE` clauses that check `seq` for
each bubblegum command.

### Discussion ideas
- One suggestion was to solve this by emit/wrapping the new leaf schema for any leaf-modifying operation. To me, that seems the easiest method that fits into what we currently are doing.
- I started looking at this and it made sense for fields like `owner` and `delegate` but I didn't immediately see how to handle things like burn that actually just set the leaf to a default value.
- Other suggestions (I still need to understand more) involve always appending to the cl_items table and potentially doing gap management natively in the database.