### PR TITLE
Adding seq number to plerkle asset tables

### DIFF
--- a/digital_asset_types/src/dao/asset.rs
+++ b/digital_asset_types/src/dao/asset.rs
@@ -35,6 +35,7 @@ pub struct Model {
     pub chain_data_id: Option<i64>,
     pub created_at: Option<DateTimeWithTimeZone>,
     pub burnt: bool,
+    pub seq: i64,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -58,6 +59,7 @@ pub enum Column {
     ChainDataId,
     CreatedAt,
     Burnt,
+    Seq,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -103,6 +105,7 @@ impl ColumnTrait for Column {
             Self::ChainDataId => ColumnType::BigInteger.def().null(),
             Self::CreatedAt => ColumnType::TimestampWithTimeZone.def().null(),
             Self::Burnt => ColumnType::Boolean.def(),
+            Self::Seq => ColumnType::BigInteger.def(),
         }
     }
 }

--- a/digital_asset_types/src/dao/asset_authority.rs
+++ b/digital_asset_types/src/dao/asset_authority.rs
@@ -18,6 +18,7 @@ pub struct Model {
     pub asset_id: Vec<u8>,
     pub scopes: Option<String>,
     pub authority: Vec<u8>,
+    pub seq: i64,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -26,6 +27,7 @@ pub enum Column {
     AssetId,
     Scopes,
     Authority,
+    Seq,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -53,6 +55,7 @@ impl ColumnTrait for Column {
             Self::AssetId => ColumnType::Binary.def(),
             Self::Scopes => ColumnType::Custom("array".to_owned()).def().null(),
             Self::Authority => ColumnType::Binary.def(),
+            Self::Seq => ColumnType::BigInteger.def(),
         }
     }
 }

--- a/digital_asset_types/src/dao/asset_creators.rs
+++ b/digital_asset_types/src/dao/asset_creators.rs
@@ -19,6 +19,7 @@ pub struct Model {
     pub creator: Vec<u8>,
     pub share: i32,
     pub verified: bool,
+    pub seq: i64,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -28,6 +29,7 @@ pub enum Column {
     Creator,
     Share,
     Verified,
+    Seq,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -56,6 +58,7 @@ impl ColumnTrait for Column {
             Self::Creator => ColumnType::Binary.def(),
             Self::Share => ColumnType::Integer.def(),
             Self::Verified => ColumnType::Boolean.def(),
+            Self::Seq => ColumnType::BigInteger.def(),
         }
     }
 }

--- a/digital_asset_types/src/dao/asset_grouping.rs
+++ b/digital_asset_types/src/dao/asset_grouping.rs
@@ -18,6 +18,7 @@ pub struct Model {
     pub asset_id: Vec<u8>,
     pub group_key: String,
     pub group_value: String,
+    pub seq: i64,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -26,6 +27,7 @@ pub enum Column {
     AssetId,
     GroupKey,
     GroupValue,
+    Seq,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -53,6 +55,7 @@ impl ColumnTrait for Column {
             Self::AssetId => ColumnType::Binary.def(),
             Self::GroupKey => ColumnType::Text.def(),
             Self::GroupValue => ColumnType::Text.def(),
+            Self::Seq => ColumnType::BigInteger.def(),
         }
     }
 }

--- a/digital_asset_types/src/dao/sea_orm_active_enums.rs
+++ b/digital_asset_types/src/dao/sea_orm_active_enums.rs
@@ -4,32 +4,22 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "chain_mutability")]
-pub enum ChainMutability {
-    #[sea_orm(string_value = "immutable")]
-    Immutable,
-    #[sea_orm(string_value = "mutable")]
-    Mutable,
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "mutability")]
-pub enum Mutability {
-    #[sea_orm(string_value = "immutable")]
-    Immutable,
-    #[sea_orm(string_value = "mutable")]
-    Mutable,
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "owner_type")]
 pub enum OwnerType {
     #[sea_orm(string_value = "single")]
     Single,
     #[sea_orm(string_value = "token")]
     Token,
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "chain_mutability")]
+pub enum ChainMutability {
+    #[sea_orm(string_value = "immutable")]
+    Immutable,
+    #[sea_orm(string_value = "mutable")]
+    Mutable,
     #[sea_orm(string_value = "unknown")]
     Unknown,
 }
@@ -46,6 +36,16 @@ pub enum RoyaltyTargetType {
     Fanout,
     #[sea_orm(string_value = "single")]
     Single,
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "mutability")]
+pub enum Mutability {
+    #[sea_orm(string_value = "immutable")]
+    Immutable,
+    #[sea_orm(string_value = "mutable")]
+    Mutable,
     #[sea_orm(string_value = "unknown")]
     Unknown,
 }

--- a/init.sql
+++ b/init.sql
@@ -130,6 +130,7 @@ create table asset_grouping
     seq         bigint                      not null
 );
 -- Limit indexable grouping keys, meaning only create on specific keys, but index the ones we allow
+create unique index asset_grouping_asset_id on asset_grouping (asset_id);
 create index asset_grouping_key on asset_grouping (group_key, group_value);
 create index asset_grouping_value on asset_grouping (group_key, asset_id);
 
@@ -142,6 +143,7 @@ create table asset_authority
     authority bytea                       not null,
     seq       bigint                      not null
 );
+create unique index asset_authority_asset_id on asset_authority (asset_id);
 create index asset_authority_idx on asset_authority (asset_id, authority);
 
 -- creators
@@ -154,6 +156,6 @@ create table asset_creators
     verified bool                        not null default false,
     seq      bigint                      not null
 );
-
+create unique index asset_creators_asset_id on asset_creators (asset_id);
 create index asset_creator on asset_creators (asset_id, creator);
 create index asset_verified_creator on asset_creators (asset_id, verified);

--- a/init.sql
+++ b/init.sql
@@ -109,7 +109,8 @@ create table asset
     chain_data_id         bigint references asset_data (id),
     -- visibility
     created_at            timestamp with time zone     default (now() at time zone 'utc'),
-    burnt                 bool                not null default false
+    burnt                 bool                not null default false,
+    seq                   bigint              not null
 );
 
 create index asset_tree on asset (tree_id);
@@ -125,7 +126,8 @@ create table asset_grouping
     id          bigserial PRIMARY KEY,
     asset_id    bytea references asset (id) not null,
     group_key   text                        not null,
-    group_value text                        not null
+    group_value text                        not null,
+    seq         bigint                      not null
 );
 -- Limit indexable grouping keys, meaning only create on specific keys, but index the ones we allow
 create index asset_grouping_key on asset_grouping (group_key, group_value);
@@ -137,7 +139,8 @@ create table asset_authority
     id        bigserial PRIMARY KEY,
     asset_id  bytea references asset (id) not null,
     scopes    text[],
-    authority bytea                       not null
+    authority bytea                       not null,
+    seq       bigint                      not null
 );
 create index asset_authority_idx on asset_authority (asset_id, authority);
 
@@ -148,9 +151,9 @@ create table asset_creators
     asset_id bytea references asset (id) not null,
     creator  bytea                       not null,
     share    int                         not null default 0,
-    verified bool                        not null default false
+    verified bool                        not null default false,
+    seq      bigint                      not null
 );
-
 
 create index asset_creator on asset_creators (asset_id, creator);
 create index asset_verified_creator on asset_creators (asset_id, verified);

--- a/init.sql
+++ b/init.sql
@@ -96,6 +96,7 @@ create table asset
     supply_mint           bytea,
     -- compression
     compressed            bool                not null default false,
+    seq                   bigint              not null,
     -- -- Can this asset be compressed
     compressible          bool                not null default false,
     tree_id               bytea,
@@ -109,8 +110,7 @@ create table asset
     chain_data_id         bigint references asset_data (id),
     -- visibility
     created_at            timestamp with time zone     default (now() at time zone 'utc'),
-    burnt                 bool                not null default false,
-    seq                   bigint              not null
+    burnt                 bool                not null default false
 );
 
 create index asset_tree on asset (tree_id);

--- a/nft_ingester/src/main.rs
+++ b/nft_ingester/src/main.rs
@@ -182,7 +182,7 @@ async fn _handle_account(manager: &ProgramHandlerManager<'static>, data: Vec<(i6
 
 async fn handle_transaction(manager: &ProgramHandlerManager<'static>, data: Vec<(i64, &[u8])>) {
     for (message_id, data) in data {
-        println!("RECV");
+        println!("RECV, data size: {}", data.len());
         //TODO -> Dedupe the stream, the stream could have duplicates as a way of ensuring fault tolerance if one validator node goes down.
         //  Possible solution is dedup on the plerkle side but this doesnt follow our principle of getting messages out of the validator asd fast as possible.
         //  Consider a Messenger Implementation detail the deduping of whats in this stream so that

--- a/nft_ingester/src/main.rs
+++ b/nft_ingester/src/main.rs
@@ -182,7 +182,7 @@ async fn _handle_account(manager: &ProgramHandlerManager<'static>, data: Vec<(i6
 
 async fn handle_transaction(manager: &ProgramHandlerManager<'static>, data: Vec<(i64, &[u8])>) {
     for (message_id, data) in data {
-        println!("RECV, data size: {}", data.len());
+        println!("RECV");
         //TODO -> Dedupe the stream, the stream could have duplicates as a way of ensuring fault tolerance if one validator node goes down.
         //  Possible solution is dedup on the plerkle side but this doesnt follow our principle of getting messages out of the validator asd fast as possible.
         //  Consider a Messenger Implementation detail the deduping of whats in this stream so that

--- a/nft_ingester/src/parsers/bubblegum.rs
+++ b/nft_ingester/src/parsers/bubblegum.rs
@@ -18,6 +18,9 @@ use {
         SqlxPostgresConnector,
         TransactionTrait,
         DatabaseTransaction,
+        sea_query::OnConflict,
+        DbBackend,
+        ExecResult,
     },
     solana_sdk::pubkeys,
     digital_asset_types::{
@@ -170,7 +173,7 @@ async fn tree_change_only<'a>(
     let gummy_roll_events = get_gummy_roll_events(logs)?;
     db.transaction::<_, _, IngesterError>(|txn| {
         Box::pin(async move {
-            save_changelog_events(gummy_roll_events, slot, txn).await?;
+            let _seq = save_changelog_events(gummy_roll_events, slot, txn).await?;
             Ok(())
         })
     })
@@ -178,9 +181,15 @@ async fn tree_change_only<'a>(
         .map_err(Into::into)
 }
 
-async fn update_asset(txn: &DatabaseTransaction, id: Vec<u8>, model: asset::ActiveModel) -> Result<asset::Model, IngesterError> {
+async fn update_asset(
+    txn: &DatabaseTransaction,
+    id: Vec<u8>,
+    seq: u64,
+    model: asset::ActiveModel,
+) -> Result<asset::Model, IngesterError> {
     asset::Entity::update(model)
         .filter(asset::Column::Id.eq(id))
+        .filter(asset::Column::Seq.lte(seq))
         .exec(txn)
         .await
         .map_err(Into::into)
@@ -202,7 +211,9 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
             let leaf_event = get_leaf_event(logs)?;
             db.transaction::<_, _, IngesterError>(|txn| {
                 Box::pin(async move {
-                    save_changelog_events(gummy_roll_events, slot, txn).await?;
+                    let seq = save_changelog_events(gummy_roll_events, slot, txn)
+                        .await?
+                        .ok_or(IngesterError::ChangeLogEventMalformed)?;
                     match leaf_event.schema {
                         LeafSchema::V1 {
                             nonce: _,
@@ -217,9 +228,10 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                                 leaf: Set(Some(leaf_event.schema.to_node().to_vec())),
                                 delegate: Set(None),
                                 owner: Set(owner_bytes),
+                                seq: Set(seq as i64), // gummyroll seq
                                 ..Default::default()
                             };
-                            update_asset(txn, id_bytes, asset_to_update).await
+                            update_asset(txn, id_bytes, seq, asset_to_update).await
                         }
                         _ => Err(IngesterError::NotImplemented)
                     }
@@ -232,7 +244,9 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
             let leaf_event = get_leaf_event(logs)?;
             db.transaction::<_, _, IngesterError>(|txn| {
                 Box::pin(async move {
-                    save_changelog_events(gummy_roll_events, slot, txn).await?;
+                    let seq = save_changelog_events(gummy_roll_events, slot, txn)
+                        .await?
+                        .ok_or(IngesterError::ChangeLogEventMalformed)?;
                     match leaf_event.schema {
                         LeafSchema::V1 {
                             id,
@@ -244,9 +258,10 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                             let asset_to_update = asset::ActiveModel {
                                 id: Unchanged(id_bytes.clone()),
                                 burnt: Set(true),
+                                seq: Set(seq as i64), // gummyroll seq
                                 ..Default::default()
                             };
-                            update_asset(txn, id_bytes, asset_to_update).await
+                            update_asset(txn, id_bytes, seq, asset_to_update).await
                         }
                         _ => Err(IngesterError::NotImplemented)
                     }
@@ -259,7 +274,9 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
             let leaf_event = get_leaf_event(logs)?;
             db.transaction::<_, _, IngesterError>(|txn| {
                 Box::pin(async move {
-                    save_changelog_events(gummy_roll_events, slot, txn).await?;
+                    let seq = save_changelog_events(gummy_roll_events, slot, txn)
+                        .await?
+                        .ok_or(IngesterError::ChangeLogEventMalformed)?;
                     match leaf_event.schema {
                         LeafSchema::V1 {
                             id,
@@ -272,9 +289,10 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                                 id: Unchanged(id_bytes.clone()),
                                 leaf: Set(Some(leaf_event.schema.to_node().to_vec())),
                                 delegate: Set(Some(delegate_bytes)),
+                                seq: Set(seq as i64), // gummyroll seq
                                 ..Default::default()
                             };
-                            update_asset(txn, id_bytes, asset_to_update).await
+                            update_asset(txn, id_bytes, seq, asset_to_update).await
                         }
                         _ => Err(IngesterError::NotImplemented)
                     }
@@ -297,7 +315,10 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
             let metadata = ix.message.clone();
             let asset_data_id = db.transaction::<_, i64, IngesterError>(|txn| {
                 Box::pin(async move {
-                    save_changelog_events(gummy_roll_events, slot, txn).await?;
+                    let seq = save_changelog_events(gummy_roll_events, slot, txn)
+                        .await?
+                        .ok_or(IngesterError::ChangeLogEventMalformed)?;
+
                     match leaf_event.schema {
                         LeafSchema::V1 {
                             nonce,
@@ -313,6 +334,10 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                                 metadata.primary_sale_happened,
                                 metadata.is_mutable,
                             );
+
+                            // Insert into `asset_data` table.  Note that if a transaction is
+                            // replayed, this will insert the data again resulting in a
+                            // duplicate entry.
                             let chain_data = ChainDataV1 {
                                 name: metadata.name,
                                 symbol: metadata.symbol,
@@ -345,17 +370,15 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                                 metadata: Set(JsonValue::String("processing".to_string())),
                                 metadata_mutability: Set(Mutability::Mutable),
                                 ..Default::default()
-                            }.insert(txn).await
-                                .map_err(|txn_err| {
-                                    IngesterError::StorageWriteError(txn_err.to_string())
-                                })?;
+                            }.insert(txn).await?;
 
+                            // Insert into `asset` table.
                             let delegate = if owner == delegate {
                                 None
                             } else {
                                 Some(delegate)
                             };
-                            asset::ActiveModel {
+                            let model = asset::ActiveModel {
                                 id: Set(id.to_bytes().to_vec()),
                                 owner: Set(owner),
                                 owner_type: Set(OwnerType::Single),
@@ -369,17 +392,57 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                                 specification_version: Set(1),
                                 nonce: Set(nonce as i64),
                                 leaf: Set(Some(leaf_event.schema.to_node().to_vec())),
-                                /// Get gummy roll seq
                                 royalty_target_type: Set(RoyaltyTargetType::Creators),
                                 royalty_target: Set(None),
                                 royalty_amount: Set(metadata.seller_fee_basis_points as i32), //basis points
                                 chain_data_id: Set(Some(data.id)),
+                                seq: Set(seq as i64), // gummyroll seq
                                 ..Default::default()
-                            }.insert(txn)
-                                .await
-                                .map_err(|txn_err| {
-                                    IngesterError::StorageWriteError(txn_err.to_string())
-                                })?;
+                            };
+
+                            // Using `INSERT` with `ON CONFLICT` and using `>= asset.seq` to allow for replaying
+                            // finalized transactions to repair entries, but not updating to a previous sequence
+                            // numbered state.
+                            let mut query = asset::Entity::insert(model)
+                                .on_conflict(
+                                    OnConflict::columns([asset::Column::Id])
+                                        .update_columns([
+                                            asset::Column::Owner,
+                                            asset::Column::OwnerType,
+                                            asset::Column::Delegate,
+                                            asset::Column::Frozen,
+                                            asset::Column::Supply,
+                                            asset::Column::SupplyMint,
+                                            asset::Column::Compressed,
+                                            asset::Column::Compressible,
+                                            asset::Column::TreeId,
+                                            asset::Column::SpecificationVersion,
+                                            asset::Column::Nonce,
+                                            asset::Column::Leaf,
+                                            asset::Column::RoyaltyTargetType,
+                                            asset::Column::RoyaltyTarget,
+                                            asset::Column::RoyaltyAmount,
+                                            asset::Column::ChainDataId,
+                                            asset::Column::Seq,
+                                        ])
+                                        .to_owned(),
+                                )
+                                .build(DbBackend::Postgres);
+                            query.sql =
+                                format!("{} WHERE excluded.seq >= asset.seq", query.sql);
+
+                            // Other method: do NOT attempt to modify any values: `ON CONFLICT DO NOTHING`.
+                            // let query = asset::Entity::insert(model)
+                            //     .on_conflict(
+                            //         OnConflict::columns([asset::Column::Id])
+                            //             .do_nothing()
+                            //             .to_owned(),
+                            //     )
+                            //     .build(DbBackend::Postgres);
+
+                            txn.execute(query).await?;
+
+                            // Insert into `asset_creators` table.
                             if metadata.creators.len() > 0 {
                                 let mut creators = Vec::with_capacity(metadata.creators.len());
                                 for c in metadata.creators {
@@ -388,37 +451,88 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                                         creator: Set(c.address.to_bytes().to_vec()),
                                         share: Set(c.share as i32),
                                         verified: Set(c.verified),
+                                        seq: Set(seq as i64), // gummyroll seq
                                         ..Default::default()
                                     });
                                 }
-                                asset_creators::Entity::insert_many(creators)
-                                    .exec(txn)
-                                    .await
-                                    .map_err(|txn_err| {
-                                        IngesterError::StorageWriteError(txn_err.to_string())
-                                    })?;
-                            }
-                            asset_authority::ActiveModel {
-                                asset_id: Set(id.to_bytes().to_vec()),
-                                authority: Set(update_authority),
-                                ..Default::default()
-                            }.insert(txn)
-                                .await
-                                .map_err(|txn_err| {
-                                    IngesterError::StorageWriteError(txn_err.to_string())
-                                })?;
-                            if let Some(c) = metadata.collection {
-                                if c.verified {
-                                    asset_grouping::ActiveModel {
-                                        asset_id: Set(id.to_bytes().to_vec()),
-                                        group_key: Set("collection".to_string()),
-                                        group_value: Set(c.key.to_string()),
-                                        ..Default::default()
-                                    }.insert(txn)
-                                        .await
-                                        .map_err(|txn_err| {
-                                            IngesterError::StorageWriteError(txn_err.to_string())
-                                        })?;
+
+                                let mut query = asset_creators::Entity::insert_many(creators)
+                                    .on_conflict(
+                                        OnConflict::columns([asset_creators::Column::AssetId])
+                                            .update_columns([
+                                                asset_creators::Column::AssetId,
+                                                asset_creators::Column::Creator,
+                                                asset_creators::Column::Share,
+                                                asset_creators::Column::Verified,
+                                                asset_creators::Column::Seq,
+                                            ])
+                                            .to_owned(),
+                                    )
+                                    .build(DbBackend::Postgres);
+                                query.sql = format!(
+                                    "{} WHERE excluded.seq >= asset_creators.seq",
+                                    query.sql
+                                );
+
+                                txn.execute(query).await?;
+
+                                // Insert into `asset_authority` table.
+                                let model = asset_authority::ActiveModel {
+                                    asset_id: Set(id.to_bytes().to_vec()),
+                                    authority: Set(update_authority),
+                                    seq: Set(seq as i64), // gummyroll seq
+                                    ..Default::default()
+                                };
+
+                                let mut query = asset_authority::Entity::insert(model)
+                                    .on_conflict(
+                                        OnConflict::columns([asset_authority::Column::AssetId])
+                                            .update_columns([
+                                                asset_authority::Column::AssetId,
+                                                asset_authority::Column::Scopes,
+                                                asset_authority::Column::Authority,
+                                                asset_authority::Column::Seq,
+                                            ])
+                                            .to_owned(),
+                                    )
+                                    .build(DbBackend::Postgres);
+                                query.sql = format!(
+                                    "{} WHERE excluded.seq >= asset_authority.seq",
+                                    query.sql
+                                );
+
+                                txn.execute(query).await?;
+
+                                // Insert into `asset_grouping` table.
+                                if let Some(c) = metadata.collection {
+                                    if c.verified {
+                                        let model = asset_grouping::ActiveModel {
+                                            asset_id: Set(id.to_bytes().to_vec()),
+                                            group_key: Set("collection".to_string()),
+                                            group_value: Set(c.key.to_string()),
+                                            seq: Set(seq as i64), // gummyroll seq
+                                            ..Default::default()
+                                        };
+
+                                        let mut query = asset_grouping::Entity::insert(model)
+                                            .on_conflict(
+                                                OnConflict::columns([asset_grouping::Column::AssetId])
+                                                    .update_columns([
+                                                        asset_grouping::Column::AssetId,
+                                                        asset_grouping::Column::GroupKey,
+                                                        asset_grouping::Column::GroupValue,
+                                                        asset_grouping::Column::Seq,
+                                                    ])
+                                                    .to_owned(),
+                                            )
+                                            .build(DbBackend::Postgres);
+                                        query.sql = format!(
+                                            "{} WHERE excluded.seq >= asset_grouping.seq",
+                                            query.sql
+                                        );
+
+                                        txn.execute(query).await?;
+                                    }
                                 }
                             }
                             Ok(data.id)
@@ -436,12 +550,14 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
             task_manager.send(Box::new(task.unwrap()))?;
         }
         bubblegum::InstructionName::Redeem => {
-            println!("Bubblegum: Redeem");
+            println!("BGUM: Redeem");
             let gummy_roll_events = get_gummy_roll_events(logs)?;
             let leaf_event = get_leaf_event(logs)?;
             db.transaction::<_, _, IngesterError>(|txn| {
                 Box::pin(async move {
-                    save_changelog_events(gummy_roll_events, slot, txn).await?;
+                    let seq = save_changelog_events(gummy_roll_events, slot, txn)
+                        .await?
+                        .ok_or(IngesterError::ChangeLogEventMalformed)?;
                     match leaf_event.schema {
                         LeafSchema::V1 {
                             id,
@@ -451,9 +567,10 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                             let asset_to_update = asset::ActiveModel {
                                 id: Unchanged(id_bytes.clone()),
                                 leaf: Set(Some(vec![0; 32])),
+                                seq: Set(seq as i64), // gummyroll seq
                                 ..Default::default()
                             };
-                            update_asset(txn, id_bytes, asset_to_update).await
+                            update_asset(txn, id_bytes, seq, asset_to_update).await
                         }
                         _ => Err(IngesterError::NotImplemented)
                     }
@@ -461,11 +578,14 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
             }).await?;
         }
         bubblegum::InstructionName::CancelRedeem => {
+            println!("BGUM: Cancel Redeem");
             let gummy_roll_events = get_gummy_roll_events(logs)?;
             let leaf_event = get_leaf_event(logs)?;
             db.transaction::<_, _, IngesterError>(|txn| {
                 Box::pin(async move {
-                    save_changelog_events(gummy_roll_events, slot, txn).await?;
+                    let seq = save_changelog_events(gummy_roll_events, slot, txn)
+                        .await?
+                        .ok_or(IngesterError::ChangeLogEventMalformed)?;
                     match leaf_event.schema {
                         LeafSchema::V1 {
                             id,
@@ -475,9 +595,10 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                             let asset_to_update = asset::ActiveModel {
                                 id: Unchanged(id_bytes.clone()),
                                 leaf: Set(Some(leaf_event.schema.to_node().to_vec())),
+                                seq: Set(seq as i64), // gummyroll seq
                                 ..Default::default()
                             };
-                            update_asset(txn, id_bytes, asset_to_update).await
+                            update_asset(txn, id_bytes, seq, asset_to_update).await
                         }
                         _ => Err(IngesterError::NotImplemented)
                     }
@@ -492,7 +613,7 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                     match decompress_event.version {
                         Version::V1 => {
                             let id_bytes = decompress_event.id.to_bytes().to_vec();
-                            let asset_to_update = asset::ActiveModel {
+                            let model = asset::ActiveModel {
                                 id: Unchanged(id_bytes.clone()),
                                 leaf: Set(None),
                                 compressed: Set(false),
@@ -501,7 +622,25 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                                 supply_mint: Set(Some(id_bytes.clone())),
                                 ..Default::default()
                             };
-                            update_asset(txn, id_bytes, asset_to_update).await
+
+                            // With this particular bubblegum instruction, there is no associated
+                            // gummyroll instruction, so there is no update to tree sequence number.
+                            // Therefore the method used with other bubblegum instructions, which is
+                            // to only do the update if
+                            // `<this instruction's seq> >= <seq num in table>` is not available.
+                            //
+                            // After the decompress instruction runs, the asset is no longer managed
+                            // by Bubblegum and Gummyroll, so there will not be any other instructions
+                            // after this one.
+                            //
+                            // Note we do not run this command if the asset is already marked as
+                            // not compressed.
+                            let query = asset::Entity::update(model)
+                                .filter(asset::Column::Id.eq(id_bytes))
+                                .filter(asset::Column::Compressed.eq(true))
+                                .build(DbBackend::Postgres);
+
+                            txn.execute(query).await.map(|_| ()).map_err(Into::into)
                         }
                         _ => Err(IngesterError::NotImplemented)
                     }

--- a/nft_ingester/src/parsers/bubblegum.rs
+++ b/nft_ingester/src/parsers/bubblegum.rs
@@ -429,38 +429,6 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                                 ..Default::default()
                             };
 
-                            // Using `INSERT` with `ON CONFLICT` and using `>= asset.seq` to allow for replaying
-                            // finalized transactions to repair entries, but not updating to a previous sequence
-                            // numbered state.
-                            // let mut query = asset::Entity::insert(model)
-                            //     .on_conflict(
-                            //         OnConflict::columns([asset::Column::Id])
-                            //             .update_columns([
-                            //                 asset::Column::Owner,
-                            //                 asset::Column::OwnerType,
-                            //                 asset::Column::Delegate,
-                            //                 asset::Column::Frozen,
-                            //                 asset::Column::Supply,
-                            //                 asset::Column::SupplyMint,
-                            //                 asset::Column::Compressed,
-                            //                 asset::Column::Compressible,
-                            //                 asset::Column::TreeId,
-                            //                 asset::Column::SpecificationVersion,
-                            //                 asset::Column::Nonce,
-                            //                 asset::Column::Leaf,
-                            //                 asset::Column::RoyaltyTargetType,
-                            //                 asset::Column::RoyaltyTarget,
-                            //                 asset::Column::RoyaltyAmount,
-                            //                 asset::Column::ChainDataId,
-                            //                 asset::Column::Seq,
-                            //             ])
-                            //             .to_owned(),
-                            //     )
-                            //     .build(DbBackend::Postgres);
-                            // query.sql =
-                            //     format!("{} WHERE excluded.seq >= asset.seq", query.sql);
-                            // txn.execute(query).await?;
-
                             // Do not attempt to modify any existing values:
                             // `ON CONFLICT ('id') DO NOTHING`.
                             let query = asset::Entity::insert(model)
@@ -486,26 +454,6 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                                     });
                                 }
 
-                                // Upsert way.
-                                // let mut query = asset_creators::Entity::insert_many(creators)
-                                //     .on_conflict(
-                                //         OnConflict::columns([asset_creators::Column::AssetId])
-                                //             .update_columns([
-                                //                 asset_creators::Column::AssetId,
-                                //                 asset_creators::Column::Creator,
-                                //                 asset_creators::Column::Share,
-                                //                 asset_creators::Column::Verified,
-                                //                 asset_creators::Column::Seq,
-                                //             ])
-                                //             .to_owned(),
-                                //     )
-                                //     .build(DbBackend::Postgres);
-                                // query.sql = format!(
-                                //     "{} WHERE excluded.seq >= asset_creators.seq",
-                                //     query.sql
-                                // );
-                                // txn.execute(query).await?;
-
                                 // Do not attempt to modify any existing values:
                                 // `ON CONFLICT ('asset_id') DO NOTHING`.
                                 let query = asset_creators::Entity::insert_many(creators)
@@ -524,25 +472,6 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                                     seq: Set(seq as i64), // gummyroll seq
                                     ..Default::default()
                                 };
-
-                                // Upsert way.
-                                // let mut query = asset_authority::Entity::insert(model)
-                                //     .on_conflict(
-                                //         OnConflict::columns([asset_authority::Column::AssetId])
-                                //             .update_columns([
-                                //                 asset_authority::Column::AssetId,
-                                //                 asset_authority::Column::Scopes,
-                                //                 asset_authority::Column::Authority,
-                                //                 asset_authority::Column::Seq,
-                                //             ])
-                                //             .to_owned(),
-                                //     )
-                                //     .build(DbBackend::Postgres);
-                                // query.sql = format!(
-                                //     "{} WHERE excluded.seq >= asset_authority.seq",
-                                //     query.sql
-                                // );
-                                // txn.execute(query).await?;
 
                                 // Do not attempt to modify any existing values:
                                 // `ON CONFLICT ('asset_id') DO NOTHING`.
@@ -565,25 +494,6 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                                             seq: Set(seq as i64), // gummyroll seq
                                             ..Default::default()
                                         };
-
-                                        // Upsert way.
-                                        // let mut query = asset_grouping::Entity::insert(model)
-                                        //     .on_conflict(
-                                        //         OnConflict::columns([asset_grouping::Column::AssetId])
-                                        //             .update_columns([
-                                        //                 asset_grouping::Column::AssetId,
-                                        //                 asset_grouping::Column::GroupKey,
-                                        //                 asset_grouping::Column::GroupValue,
-                                        //                 asset_grouping::Column::Seq,
-                                        //             ])
-                                        //             .to_owned(),
-                                        //     )
-                                        //     .build(DbBackend::Postgres);
-                                        // query.sql = format!(
-                                        //     "{} WHERE excluded.seq >= asset_grouping.seq",
-                                        //     query.sql
-                                        // );
-                                        // txn.execute(query).await?;
 
                                     // Do not attempt to modify any existing values:
                                     // `ON CONFLICT ('asset_id') DO NOTHING`.

--- a/nft_ingester/src/parsers/bubblegum.rs
+++ b/nft_ingester/src/parsers/bubblegum.rs
@@ -231,6 +231,9 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                 Box::pin(async move {
                     let seq = save_changelog_events(gummy_roll_events, slot, txn)
                         .await?
+                        .iter()
+                        .max()
+                        .map(|v| *v)
                         .ok_or(IngesterError::ChangeLogEventMalformed)?;
                     match leaf_event.schema {
                         LeafSchema::V1 {
@@ -267,8 +270,11 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
             let leaf_event = get_leaf_event(logs)?;
             db.transaction::<_, _, IngesterError>(|txn| {
                 Box::pin(async move {
-                    let seq = save_changelog_events(gummy_roll_events, slot, txn)
+                    let _seq = save_changelog_events(gummy_roll_events, slot, txn)
                         .await?
+                        .iter()
+                        .max()
+                        .map(|v| *v)
                         .ok_or(IngesterError::ChangeLogEventMalformed)?;
                     match leaf_event.schema {
                         LeafSchema::V1 {
@@ -298,6 +304,9 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                 Box::pin(async move {
                     let seq = save_changelog_events(gummy_roll_events, slot, txn)
                         .await?
+                        .iter()
+                        .max()
+                        .map(|v| *v)
                         .ok_or(IngesterError::ChangeLogEventMalformed)?;
                     match leaf_event.schema {
                         LeafSchema::V1 {
@@ -346,8 +355,10 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                 Box::pin(async move {
                     let seq = save_changelog_events(gummy_roll_events, slot, txn)
                         .await?
+                        .iter()
+                        .max()
+                        .map(|v| *v)
                         .ok_or(IngesterError::ChangeLogEventMalformed)?;
-
                     match leaf_event.schema {
                         LeafSchema::V1 {
                             nonce,
@@ -530,6 +541,9 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                 Box::pin(async move {
                     let seq = save_changelog_events(gummy_roll_events, slot, txn)
                         .await?
+                        .iter()
+                        .max()
+                        .map(|v| *v)
                         .ok_or(IngesterError::ChangeLogEventMalformed)?;
                     match leaf_event.schema {
                         LeafSchema::V1 {
@@ -568,6 +582,9 @@ async fn handle_bubblegum_instruction<'a, 'b, 't>(
                 Box::pin(async move {
                     let seq = save_changelog_events(gummy_roll_events, slot, txn)
                         .await?
+                        .iter()
+                        .max()
+                        .map(|v| *v)
                         .ok_or(IngesterError::ChangeLogEventMalformed)?;
                     match leaf_event.schema {
                         LeafSchema::V1 {


### PR DESCRIPTION
### Notes
- This PR should work for what we have today, but now that the backfiller is another data source for the various database tables, we may want to revisit some of our strategies for `cl_items` and the various asset tables, since they can now get events out of order.

### Background
- This PR is needed to support replaying of Bubblegum instructions and avoid putting old data in various asset tables.
- Modifying `INSERT` statements for Bubblegum Mint instructions to have `ON_CONFLICT DO NOTHING` clauses.
 - This allows us to replay a `mint` instruction if there was a failure that caused some of the inserts to various tables to be missing.
- Modifying `UPDATE` statements for other Bubblegum instructions to have `WHERE` clauses that check `seq`.
  - There is/was a potential issue with this, because not every Bubblegum instruction writes the same fields to the asset tables.
  - **Problem:** If we always update the asset tables when we run old instructions during backfilling, then we might update newer data with old data.  On the other hand, If we always check the sequence number for the asset table before running the old instruction, we may miss updates from older instructions because the newer instructions might not have updated the exact same fields.
  - **Solution:** One suggestion was to always write all the relevant fields.  For example, have the Bubblegum `delegate` instruction processing also write `owner` to the database even though `owner` would not be changing during a `delegate` instruction.  The relevant fields are present in the leaf schema today.
  - Note the `burn` command and the `decompress` command cannot follow this idea for different reasons, but I don't think anything could run after these commands anyways.  So `burn` and `decompress` instructions are allowed to always be replayed.

### Other ideas
- Other suggestions involve always appending to the `cl_items` table and potentially doing gap management natively in the database.