### PR TITLE
Set freeze authority on decompressed tokens

### DIFF
--- a/contracts/programs/bubblegum/src/lib.rs
+++ b/contracts/programs/bubblegum/src/lib.rs
@@ -892,7 +892,7 @@ pub mod bubblegum {
                             &spl_token::id(),
                             &ctx.accounts.mint.key(),
                             &ctx.accounts.mint_authority.key(),
-                            None,
+                            Some(&ctx.accounts.mint_authority.key()),
                             0,
                         )?,
                         &[


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10461812/183235311-0ec6b4fa-d3f4-4771-adce-e99c93f5d53b.png)
noticed this - many dapps (like cardinal staking) rely on freeze authority being present, so tokens can be frozen in the user's wallet. no reason to not set this afaik