### PR TITLE
CMT: Subtree Append

### DIFF
--- a/lib/concurrent-merkle-tree/src/error.rs
+++ b/lib/concurrent-merkle-tree/src/error.rs
@@ -35,4 +35,16 @@ pub enum CMTError {
         "Valid proof was passed to a leaf, but it's value has changed since the proof was issued"
     )]
     LeafContentsModified,
+
+    /// Attempted to append subtree to initialize a tree
+    #[error(
+        "Cannot initialize tree with subtree append"
+    )]
+    CannotInitializeWithSubtreeAppend,
+
+    /// Attempted to append subtree of invalid size for the current state of the tree
+    #[error(
+        "Cannot append subtree with invalid size"
+    )]
+    SubtreeInvalidSize
 }

--- a/lib/concurrent-merkle-tree/src/error.rs
+++ b/lib/concurrent-merkle-tree/src/error.rs
@@ -37,14 +37,10 @@ pub enum CMTError {
     LeafContentsModified,
 
     /// Attempted to append subtree to initialize a tree
-    #[error(
-        "Cannot initialize tree with subtree append"
-    )]
+    #[error("Cannot initialize tree with subtree append")]
     CannotInitializeWithSubtreeAppend,
 
     /// Attempted to append subtree of invalid size for the current state of the tree
-    #[error(
-        "Cannot append subtree with invalid size"
-    )]
-    SubtreeInvalidSize
+    #[error("Cannot append subtree with invalid size")]
+    SubtreeInvalidSize,
 }

--- a/lib/concurrent-merkle-tree/src/merkle_roll.rs
+++ b/lib/concurrent-merkle-tree/src/merkle_roll.rs
@@ -144,7 +144,7 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize> MerkleRoll<MAX_DEPTH,
         }
     }
 
-    /// Basic operation that always succeeds
+    /// Append leaf to tree
     pub fn append(&mut self, mut node: Node) -> Result<Node, CMTError> {
         check_bounds(MAX_DEPTH, MAX_BUFFER_SIZE);
         if node == EMPTY {
@@ -193,6 +193,86 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize> MerkleRoll<MAX_DEPTH,
             ChangeLog::<MAX_DEPTH>::new(node, change_list, self.rightmost_proof.index);
         self.rightmost_proof.index = self.rightmost_proof.index + 1;
         self.rightmost_proof.leaf = leaf;
+        Ok(node)
+    }
+
+    /// Append subtree to current tree
+    /// TODO(sorend): consider changing this function to just take in a merkle_roll argument rather than each of these component pieces. Might be hard with all of the different possible merkle roll dpeth, buffer size combinations
+    pub fn append_subtree(&mut self, subtree_root: Node, subtree_rightmost_leaf: Node, subtree_rightmost_index: u32, subtree_rightmost_proof: Vec<Node>) -> Result<Node, CMTError> {
+        println!("1");
+        check_bounds(MAX_DEPTH, MAX_BUFFER_SIZE);
+        // TODO: consider adding check that the subtree is not empty (but will omit for now)
+        //       Some factors: it will be more time consuming to check that the root subtree_root is not an empty_root, because it requires applying O(depth) hashes of trivial nodes
+        println!("2");
+        if self.rightmost_proof.index >= 1 << MAX_DEPTH {
+            return Err(CMTError::TreeFull);
+        }
+
+        println!("3");
+        if self.rightmost_proof.index == 0 {
+            // TODO(sorend): write an equivallent function for subtree_append: initialize_tree_from_subtree_append
+            return Ok(subtree_root);
+        }
+
+        println!("4");
+        // Confirm that subtree_rightmost_proof hashes to subtree_root
+        if recompute(subtree_rightmost_leaf, &subtree_rightmost_proof[..], subtree_rightmost_index) != subtree_root {
+            return Err(CMTError::InvalidProof);
+        }
+
+        println!("5");
+        let leaf = subtree_rightmost_leaf.clone();
+
+        // I believe that this is still correct
+        let intersection = self.rightmost_proof.index.trailing_zeros() as usize;
+        let mut change_list = [EMPTY; MAX_DEPTH];
+        let mut intersection_node = self.rightmost_proof.leaf;
+        // let mut empty_node_cache = Box::new([Node::default(); MAX_DEPTH]);
+
+        // This will be mutated into the new root
+        let mut node = subtree_rightmost_leaf;
+
+        println!("6");
+        for i in 0..MAX_DEPTH {
+            change_list[i] = node;
+            if i < intersection {
+                println!("ran i less than intersection");
+                // Compute proof to the appended node from empty nodes
+                hash_to_parent(
+                    &mut intersection_node,
+                    &self.rightmost_proof.proof[i],
+                    ((self.rightmost_proof.index - 1) >> i) & 1 == 0,
+                );
+                hash_to_parent(&mut node, &subtree_rightmost_proof[i], false);
+                self.rightmost_proof.proof[i] = subtree_rightmost_proof[i];
+            } else if i == intersection {
+                println!("ran i equals intersection");
+                // Compute the where the new node intersects the main tree
+                hash_to_parent(&mut node, &intersection_node, false);
+                self.rightmost_proof.proof[intersection] = intersection_node;
+            } else {
+                println!("ran i more than intersection");
+                // Update the change list path up to the root
+                hash_to_parent(
+                    &mut node,
+                    &self.rightmost_proof.proof[i],
+                    ((self.rightmost_proof.index - 1) >> i) & 1 == 0,
+                );
+            }
+        }
+
+        println!("at the end");
+
+        self.update_internal_counters();
+        self.change_logs[self.active_index as usize] =
+            ChangeLog::<MAX_DEPTH>::new(node, change_list, self.rightmost_proof.index);
+        self.rightmost_proof.index = self.rightmost_proof.index + 1;
+        self.rightmost_proof.leaf = leaf;
+
+        println!("supplied rightmost leaf {:?}", subtree_rightmost_leaf);
+        println!("rightmost proof leaf saved to tree {:?}", self.rightmost_proof.leaf);
+
+        println!("at the very end");
         Ok(node)
     }
 

--- a/lib/concurrent-merkle-tree/src/merkle_roll.rs
+++ b/lib/concurrent-merkle-tree/src/merkle_roll.rs
@@ -206,7 +206,7 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize> MerkleRoll<MAX_DEPTH,
     ) -> Result<Node, CMTError> {
         check_bounds(MAX_DEPTH, MAX_BUFFER_SIZE);
         // TODO: consider adding check that the subtree is not empty (but will omit for now)
-        //       note: it will be more time consuming to check that the root subtree_root is not an empty_root, because it requires applying O(depth) hashes of trivial nodes
+        //       note: it will be more time consuming to check that the subtree_root is not a root to an empty tree, because it requires applying O(depth) hashes of trivial nodes
         if self.rightmost_proof.index >= 1 << MAX_DEPTH {
             return Err(CMTError::TreeFull);
         }
@@ -217,7 +217,7 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize> MerkleRoll<MAX_DEPTH,
             return Err(CMTError::CannotInitializeWithSubtreeAppend);
         }
 
-        // Confirm that subtree_rightmost_proof hashes to subtree_root
+        // Confirm that subtree_rightmost_proof is valid
         if recompute(
             subtree_rightmost_leaf,
             &subtree_rightmost_proof[..],
@@ -257,7 +257,7 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize> MerkleRoll<MAX_DEPTH,
                 );
                 self.rightmost_proof.proof[i] = subtree_rightmost_proof[i];
             } else if i == intersection {
-                // Compute the where the new node intersects the main tree
+                // Compute where the new node intersects the main tree
                 hash_to_parent(&mut node, &intersection_node, false);
                 self.rightmost_proof.proof[intersection] = intersection_node;
             } else {

--- a/lib/concurrent-merkle-tree/src/merkle_roll.rs
+++ b/lib/concurrent-merkle-tree/src/merkle_roll.rs
@@ -197,7 +197,6 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize> MerkleRoll<MAX_DEPTH,
     }
 
     /// Append subtree to current tree
-    /// TODO(sorend): consider changing this function to just take in a merkle_roll argument rather than each of these component pieces. Might be hard with all of the different possible merkle roll dpeth, buffer size combinations
     pub fn append_subtree(&mut self, subtree_root: Node, subtree_rightmost_leaf: Node, subtree_rightmost_index: u32, subtree_rightmost_proof: Vec<Node>) -> Result<Node, CMTError> {
         check_bounds(MAX_DEPTH, MAX_BUFFER_SIZE);
         // TODO: consider adding check that the subtree is not empty (but will omit for now)

--- a/lib/concurrent-merkle-tree/src/state.rs
+++ b/lib/concurrent-merkle-tree/src/state.rs
@@ -37,7 +37,12 @@ impl<const MAX_DEPTH: usize> ChangeLog<MAX_DEPTH> {
     }
 
     /// Sets all change log values from a leaf and valid proof
-    pub fn replace_and_recompute_path(&mut self, index: u32, mut node: Node, proof: &[Node]) -> Node {
+    pub fn replace_and_recompute_path(
+        &mut self,
+        index: u32,
+        mut node: Node,
+        proof: &[Node],
+    ) -> Node {
         self.index = index;
         for (i, sibling) in proof.iter().enumerate() {
             self.path[i] = node;

--- a/lib/concurrent-merkle-tree/tests/tests.rs
+++ b/lib/concurrent-merkle-tree/tests/tests.rs
@@ -141,7 +141,7 @@ async fn test_append_incomplete_subtree() {
     onchain_subtree.initialize().unwrap();
 
     // append leaves to the subtree, and also append them to the off-chain tree
-    // note: this gives us a partially filled tree, the other two leaves are trivially empty nodes
+    // note: this gives us a partially filled tree, the other two leaves are empty nodes
     for i in 4..6 {
         let leaf = rng.gen::<[u8; 32]>();
         onchain_subtree.append(leaf).unwrap();

--- a/lib/concurrent-merkle-tree/tests/tests.rs
+++ b/lib/concurrent-merkle-tree/tests/tests.rs
@@ -26,7 +26,6 @@ fn setup() -> (MerkleRoll<DEPTH, BUFFER_SIZE>, MerkleTree) {
     (merkle, reference_tree)
 }
 
-
 #[tokio::test(threaded_scheduler)]
 async fn test_initialize() {
     let (mut merkle_roll, off_chain_tree) = setup();
@@ -62,7 +61,6 @@ async fn test_append() {
     );
 }
 
-
 #[tokio::test(threaded_scheduler)]
 async fn test_append_complete_subtree() {
     let (mut merkle_roll, mut off_chain_tree) = setup();
@@ -84,7 +82,7 @@ async fn test_append_complete_subtree() {
     // create a simple subtree to append of depth three
     let mut onchain_subtree = MerkleRoll::<3, 8>::new();
     onchain_subtree.initialize().unwrap();
-    
+
     // completely fill the subtree with unique leaves, and also append them to the off-chain tree
     for i in 8..16 {
         let leaf = rng.gen::<[u8; 32]>();
@@ -93,24 +91,31 @@ async fn test_append_complete_subtree() {
     }
 
     // append the on_chain subtree to the merkle_roll
-    merkle_roll.append_subtree(onchain_subtree.get_change_log().root, onchain_subtree.rightmost_proof.leaf, onchain_subtree.rightmost_proof.index, onchain_subtree.rightmost_proof.proof.to_vec()).unwrap();
+    merkle_roll
+        .append_subtree(
+            onchain_subtree.get_change_log().root,
+            onchain_subtree.rightmost_proof.leaf,
+            onchain_subtree.rightmost_proof.index,
+            onchain_subtree.rightmost_proof.proof.to_vec(),
+        )
+        .unwrap();
 
-    // The result should be that the merkle_roll's new root is the same as the root of the off-chain tree which had leaves 0..15 manually inserted
-     assert_eq!(
+    // The result should be that the merkle_roll's new root is the same as the root of the off-chain tree which had leaves 0..15 appended one by one
+    assert_eq!(
         merkle_roll.get_change_log().root,
         off_chain_tree.get_root(),
         "On chain tree failed to update properly on an append",
     );
 
-     // Show that we can still append to the large tree after performing a subtree append
-     let leaf = rng.gen::<[u8; 32]>();
-     merkle_roll.append(leaf).unwrap();
-     off_chain_tree.add_leaf(leaf, 16);
-     assert_eq!(
-         merkle_roll.get_change_log().root,
-         off_chain_tree.get_root(),
-         "Failed to append accurately to merkle roll after subtree append",
-     );
+    // Show that we can still append to the large tree after performing a subtree append
+    let leaf = rng.gen::<[u8; 32]>();
+    merkle_roll.append(leaf).unwrap();
+    off_chain_tree.add_leaf(leaf, 16);
+    assert_eq!(
+        merkle_roll.get_change_log().root,
+        off_chain_tree.get_root(),
+        "Failed to append accurately to merkle roll after subtree append",
+    );
 }
 
 #[tokio::test(threaded_scheduler)]
@@ -134,7 +139,7 @@ async fn test_append_incomplete_subtree() {
     // create a simple subtree to append of depth three
     let mut onchain_subtree = MerkleRoll::<2, 8>::new();
     onchain_subtree.initialize().unwrap();
-    
+
     // append leaves to the subtree, and also append them to the off-chain tree
     // note: this gives us a partially filled tree, the other two leaves are trivially empty nodes
     for i in 4..6 {
@@ -144,9 +149,16 @@ async fn test_append_incomplete_subtree() {
     }
 
     // append the on_chain subtree to the merkle_roll
-    merkle_roll.append_subtree(onchain_subtree.get_change_log().root, onchain_subtree.rightmost_proof.leaf, onchain_subtree.rightmost_proof.index, onchain_subtree.rightmost_proof.proof.to_vec()).unwrap();
+    merkle_roll
+        .append_subtree(
+            onchain_subtree.get_change_log().root,
+            onchain_subtree.rightmost_proof.leaf,
+            onchain_subtree.rightmost_proof.index,
+            onchain_subtree.rightmost_proof.proof.to_vec(),
+        )
+        .unwrap();
 
-    // The result should be that the merkle_roll's new root is the same as the root of the off-chain tree which had leaves 0..5 manually inserted
+    // The result should be that the merkle_roll's new root is the same as the root of the off-chain tree which had leaves 0..5 appended one by one
     assert_eq!(
         merkle_roll.get_change_log().root,
         off_chain_tree.get_root(),
@@ -163,7 +175,6 @@ async fn test_append_incomplete_subtree() {
         "Failed to append accurately to merkle roll after subtree append",
     );
 }
-
 
 #[tokio::test(threaded_scheduler)]
 async fn test_prove_leaf() {

--- a/lib/concurrent-merkle-tree/tests/tests.rs
+++ b/lib/concurrent-merkle-tree/tests/tests.rs
@@ -26,6 +26,7 @@ fn setup() -> (MerkleRoll<DEPTH, BUFFER_SIZE>, MerkleTree) {
     (merkle, reference_tree)
 }
 
+/*
 #[tokio::test(threaded_scheduler)]
 async fn test_initialize() {
     let (mut merkle_roll, off_chain_tree) = setup();
@@ -59,8 +60,120 @@ async fn test_append() {
         merkle_roll.buffer_size, BUFFER_SIZE as u64,
         "Merkle roll buffer size is wrong"
     );
+}*/
+
+
+#[tokio::test(threaded_scheduler)]
+async fn test_subtree_append() {
+    let (mut merkle_roll, mut off_chain_tree) = setup();
+    let mut rng = thread_rng();
+    merkle_roll.initialize().unwrap();
+
+    // insert eight leaves into the large tree
+    let mut first_leaves = vec![];
+    for i in 0..8 {
+        let leaf = rng.gen::<[u8; 32]>();
+        first_leaves.push(leaf);
+        merkle_roll.append(leaf).unwrap();
+        off_chain_tree.add_leaf(leaf, i);
+        assert_eq!(
+            merkle_roll.get_change_log().root,
+            off_chain_tree.get_root(),
+            "On chain tree failed to update properly on an append",
+        );
+    }
+
+    println!(
+        "testing"
+    );
+
+    // create a simple subtree to append of depth three
+    let mut onchain_subtree = MerkleRoll::<3, 8>::new();
+    onchain_subtree.initialize().unwrap();
+    
+    // append leaves to the subtree, and also append them to the off-chain tree
+    let mut leaves = vec![];
+    for i in 8..16 {
+        let leaf = rng.gen::<[u8; 32]>();
+        leaves.push(leaf);
+        onchain_subtree.append(leaf).unwrap();
+        off_chain_tree.add_leaf(leaf, i);
+    }
+
+    println!("leaf we want to writeback to rightmost proof leaf {:?}", onchain_subtree.rightmost_proof.leaf);
+
+    // APPEND the on_chain subtree to the merkle_roll
+    let res = merkle_roll.append_subtree(onchain_subtree.get_change_log().root, onchain_subtree.rightmost_proof.leaf, onchain_subtree.rightmost_proof.index-1, onchain_subtree.rightmost_proof.proof.to_vec());
+    let unwrapped_res = res.unwrap();
+
+    println!("written back rightmost proof leaf {:?}", merkle_roll.rightmost_proof.leaf);
+
+    println!("{:?}", unwrapped_res);
+
+    // The result should be that the merkle_roll's new root is the same as the root of the off-chain tree which had leaves 0..15 manually inserted
+     assert_eq!(
+        merkle_roll.get_change_log().root,
+        off_chain_tree.get_root(),
+        "On chain tree failed to update properly on an append",
+    );
 }
 
+#[tokio::test(threaded_scheduler)]
+async fn test_subtree_append_2() {
+    let (mut merkle_roll, mut off_chain_tree) = setup();
+    let mut rng = thread_rng();
+    merkle_roll.initialize().unwrap();
+
+    // insert eight leaves into the large tree
+    let mut merkle_roll_leaves = vec![];
+    for i in 0..2 {
+        let leaf = rng.gen::<[u8; 32]>();
+        merkle_roll_leaves.push(leaf);
+        merkle_roll.append(leaf).unwrap();
+        off_chain_tree.add_leaf(leaf, i);
+        assert_eq!(
+            merkle_roll.get_change_log().root,
+            off_chain_tree.get_root(),
+            "On chain tree failed to update properly on an append",
+        );
+    }
+
+    println!(
+        "testing"
+    );
+
+    // create a simple subtree to append of depth three
+    let mut onchain_subtree = MerkleRoll::<1, 8>::new();
+    onchain_subtree.initialize().unwrap();
+    
+    // append leaves to the subtree, and also append them to the off-chain tree
+    let mut subtree_leaves = vec![];
+    for i in 2..4 {
+        let leaf = rng.gen::<[u8; 32]>();
+        subtree_leaves.push(leaf);
+        onchain_subtree.append(leaf).unwrap();
+        off_chain_tree.add_leaf(leaf, i);
+    }
+
+    println!("leaf we want to writeback to rightmost proof leaf {:?}", onchain_subtree.rightmost_proof.leaf);
+
+    // APPEND the on_chain subtree to the merkle_roll
+    let res = merkle_roll.append_subtree(onchain_subtree.get_change_log().root, onchain_subtree.rightmost_proof.leaf, onchain_subtree.rightmost_proof.index-1, onchain_subtree.rightmost_proof.proof.to_vec());
+    let unwrapped_res = res.unwrap();
+
+    println!("written back rightmost proof leaf {:?}", merkle_roll.rightmost_proof.leaf);
+
+    println!("{:?}", unwrapped_res);
+
+    // The result should be that the merkle_roll's new root is the same as the root of the off-chain tree which had leaves 0..15 manually inserted
+     assert_eq!(
+        merkle_roll.get_change_log().root,
+        off_chain_tree.get_root(),
+        "On chain tree failed to update properly on an append",
+    );
+}
+
+/* 
 #[tokio::test(threaded_scheduler)]
 async fn test_prove_leaf() {
     let (mut merkle_roll, mut off_chain_tree) = setup();
@@ -396,4 +509,4 @@ async fn test_append_bug_repro_2() {
     }
     last_rmp = merkle_roll.rightmost_proof;
     assert_eq!(merkle_roll.get_change_log().root, tree.get_root());
-}
+}*/


### PR DESCRIPTION
This PR adds functionality to append a subtree to a CMT!

The high-level process roughly goes as follows (similar to what @jarry-xiao initially outlined):
- Check that we are NOT trying to initialize the tree with an append (see below)
- Check that the subtree proof is valid for the subtree root
- Compute the new root of the tree by hashing the right most subtree leaf with other nodes in its rightmost proof, and then with the critical node (in the larger tree), and then with other nodes in the rightmost tree's RMP.
- Writeback the new changelog corresponding to the RML in the subtree
- Update the RMP index by incrementing it by the subtree's rightmost index

Why we only need one changelog in order to accurately fast-forward proofs for subsequent `replace_leaf` calls.
[Subtree append.pdf](https://github.com/jarry-xiao/candyland/files/9311928/Subtree.append.pdf)

Why we don't allow initializing a CMT via subtree append (for now, worth for the future?):
[Subtree append 2.pdf](https://github.com/jarry-xiao/candyland/files/9311930/Subtree.append.2.pdf)

